### PR TITLE
Update 2 functions to return a pair rather than empty tuple

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -1024,7 +1024,7 @@ def getCleanMovieTitle(path, usefoldername=False):
 
         title, year = xbmc.getCleanMovieTitle('/path/to/moviefolder/test.avi', True)
     """
-    return tuple()
+    return str(), str()
 
 
 def getCondVisibility(condition):

--- a/xbmcvfs.py
+++ b/xbmcvfs.py
@@ -211,7 +211,7 @@ def listdir(path):
 
         dirs, files = xbmcvfs.listdir(path)
     """
-    return tuple()
+    return list(), list()
 
 
 class Stat(object):


### PR DESCRIPTION
`xnmcvfs.listdir` returns a pair of lists, and `xbmc.getCleanMovieTitle` returns a pair of strings.

This avoids unbalanced tuple unpacking warnings from pylint and such when assigning multiple variables like the examples.