### PR TITLE
fix: add imports to top of files

### DIFF
--- a/xbmc.py
+++ b/xbmc.py
@@ -10,6 +10,7 @@ song). You can also find system information using the functions available in
 this library.
 """
 from typing import Union, List, Dict, Tuple, Optional
+from xbmcgui import ListItem
 
 __kodistubs__ = True
 
@@ -49,15 +50,15 @@ class InfoTagGame:
 
         ...
         tag = item.getGameInfoTag()
-        
+
         title = tag.getTitle()
         tag.setDeveloper('John Doe')
         ...
     """
-    
+
     def __init__(self, offscreen: bool = False) -> None:
         pass
-    
+
     def getTitle(self) -> str:
         """
         Gets the title of the game.
@@ -67,7 +68,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getPlatform(self) -> str:
         """
         Gets the platform on which the game is run.
@@ -77,7 +78,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getGenres(self) -> List[str]:
         """
         Gets the genres of the game.
@@ -87,7 +88,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return [""]
-    
+
     def getPublisher(self) -> str:
         """
         Gets the publisher of the game.
@@ -97,7 +98,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getDeveloper(self) -> str:
         """
         Gets the developer of the game.
@@ -107,7 +108,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getOverview(self) -> str:
         """
         Gets the overview of the game.
@@ -117,7 +118,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getYear(self) -> int:
         """
         Gets the year in which the game was published.
@@ -127,7 +128,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getGameClient(self) -> str:
         """
         Gets the add-on ID of the game client executing the game.
@@ -137,7 +138,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         return ""
-    
+
     def setTitle(self, title: str) -> None:
         """
         Sets the title of the game.
@@ -147,7 +148,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setPlatform(self, platform: str) -> None:
         """
         Sets the platform on which the game is run.
@@ -157,7 +158,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setGenres(self, genres: List[str]) -> None:
         """
         Sets the genres of the game.
@@ -167,7 +168,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setPublisher(self, publisher: str) -> None:
         """
         Sets the publisher of the game.
@@ -177,7 +178,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setDeveloper(self, developer: str) -> None:
         """
         Sets the developer of the game.
@@ -187,7 +188,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setOverview(self, overview: str) -> None:
         """
         Sets the overview of the game.
@@ -197,7 +198,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setYear(self, year: int) -> None:
         """
         Sets the year in which the game was published.
@@ -207,7 +208,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
     def setGameClient(self, gameClient: str) -> None:
         """
         Sets the add-on ID of the game client executing the game.
@@ -217,7 +218,7 @@ class InfoTagGame:
         @python_v20 New function added.
         """
         pass
-    
+
 
 class InfoTagMusic:
     """
@@ -229,15 +230,15 @@ class InfoTagMusic:
 
         ...
         tag = xbmc.Player().getMusicInfoTag()
-        
+
         title = tag.getTitle()
         url   = tag.getURL()
         ...
     """
-    
+
     def __init__(self, offscreen: bool = False) -> None:
         pass
-    
+
     def getDbId(self) -> int:
         """
         Get identification number of tag in database.
@@ -247,7 +248,7 @@ class InfoTagMusic:
         @python_v18 New function added.
         """
         return 0
-    
+
     def getURL(self) -> str:
         """
         Returns url of source as string from music info tag.
@@ -255,7 +256,7 @@ class InfoTagMusic:
         :return: [string] Url of source
         """
         return ""
-    
+
     def getTitle(self) -> str:
         """
         Returns the title from music as string on info tag.
@@ -263,7 +264,7 @@ class InfoTagMusic:
         :return: [string] Music title
         """
         return ""
-    
+
     def getMediaType(self) -> str:
         """
         Get the media type of the music item.
@@ -272,18 +273,18 @@ class InfoTagMusic:
 
         Available strings about media type for music:
 
-        ====== ============================= 
-        String Description                   
-        ====== ============================= 
-        artist If it is defined as an artist 
-        album  If it is defined as an album  
-        song   If it is defined as a song    
-        ====== ============================= 
+        ====== =============================
+        String Description
+        ====== =============================
+        artist If it is defined as an artist
+        album  If it is defined as an album
+        song   If it is defined as a song
+        ====== =============================
 
         @python_v18 New function added.
         """
         return ""
-    
+
     def getArtist(self) -> str:
         """
         Returns the artist from music as string if present.
@@ -291,7 +292,7 @@ class InfoTagMusic:
         :return: [string] Music artist
         """
         return ""
-    
+
     def getAlbum(self) -> str:
         """
         Returns the album from music tag as string if present.
@@ -299,7 +300,7 @@ class InfoTagMusic:
         :return: [string] Music album name
         """
         return ""
-    
+
     def getAlbumArtist(self) -> str:
         """
         Returns the album artist from music tag as string if present.
@@ -307,7 +308,7 @@ class InfoTagMusic:
         :return: [string] Music album artist name
         """
         return ""
-    
+
     def getGenre(self) -> str:
         """
         Returns the genre name from music tag as string if present.
@@ -317,7 +318,7 @@ class InfoTagMusic:
         @python_v20 Deprecated. Use **`getGenres()`** instead.
         """
         return ""
-    
+
     def getGenres(self) -> List[str]:
         """
         Returns the list of genres from music tag if present.
@@ -327,7 +328,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         return [""]
-    
+
     def getDuration(self) -> int:
         """
         Returns the duration of music as integer from info tag.
@@ -335,7 +336,7 @@ class InfoTagMusic:
         :return: [integer] Duration
         """
         return 0
-    
+
     def getYear(self) -> int:
         """
         Returns the year of music as integer from info tag.
@@ -345,7 +346,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getRating(self) -> int:
         """
         Returns the scraped rating as integer.
@@ -353,7 +354,7 @@ class InfoTagMusic:
         :return: [integer] Rating
         """
         return 0
-    
+
     def getUserRating(self) -> int:
         """
         Returns the user rating as integer (-1 if not existing)
@@ -361,7 +362,7 @@ class InfoTagMusic:
         :return: [integer] User rating
         """
         return 0
-    
+
     def getTrack(self) -> int:
         """
         Returns the track number (if present) from music info tag as integer.
@@ -369,7 +370,7 @@ class InfoTagMusic:
         :return: [integer] Track number
         """
         return 0
-    
+
     def getDisc(self) -> int:
         """
         Returns the disk number (if present) from music info tag as integer.
@@ -377,7 +378,7 @@ class InfoTagMusic:
         :return: [integer] Disc number
         """
         return 0
-    
+
     def getReleaseDate(self) -> str:
         """
         Returns the release date as string from music info tag (if present).
@@ -385,7 +386,7 @@ class InfoTagMusic:
         :return: [string] Release date
         """
         return ""
-    
+
     def getListeners(self) -> int:
         """
         Returns the listeners as integer from music info tag.
@@ -393,7 +394,7 @@ class InfoTagMusic:
         :return: [integer] Listeners
         """
         return 0
-    
+
     def getPlayCount(self) -> int:
         """
         Returns the number of carried out playbacks.
@@ -401,7 +402,7 @@ class InfoTagMusic:
         :return: [integer] Playback count
         """
         return 0
-    
+
     def getLastPlayed(self) -> str:
         """
         Returns last played time as string from music info tag.
@@ -411,7 +412,7 @@ class InfoTagMusic:
         @python_v20 Deprecated. Use **`getLastPlayedAsW3C()`** instead.
         """
         return ""
-    
+
     def getLastPlayedAsW3C(self) -> str:
         """
         Returns last played time as string in W3C format (YYYY-MM-DDThh:mm:ssTZD).
@@ -421,7 +422,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getComment(self) -> str:
         """
         Returns comment as string from music info tag.
@@ -429,7 +430,7 @@ class InfoTagMusic:
         :return: [string] Comment on tag
         """
         return ""
-    
+
     def getLyrics(self) -> str:
         """
         Returns a string from lyrics.
@@ -437,7 +438,7 @@ class InfoTagMusic:
         :return: [string] Lyrics on tag
         """
         return ""
-    
+
     def getMusicBrainzTrackID(self) -> str:
         """
         Returns the MusicBrainz Recording ID from music info tag (if present).
@@ -447,7 +448,7 @@ class InfoTagMusic:
         @python_v19 New function added.
         """
         return ""
-    
+
     def getMusicBrainzArtistID(self) -> List[str]:
         """
         Returns the MusicBrainz Artist IDs from music info tag (if present).
@@ -457,7 +458,7 @@ class InfoTagMusic:
         @python_v19 New function added.
         """
         return [""]
-    
+
     def getMusicBrainzAlbumID(self) -> str:
         """
         Returns the MusicBrainz Release ID from music info tag (if present).
@@ -467,7 +468,7 @@ class InfoTagMusic:
         @python_v19 New function added.
         """
         return ""
-    
+
     def getMusicBrainzReleaseGroupID(self) -> str:
         """
         Returns the MusicBrainz Release Group ID from music info tag (if present).
@@ -477,7 +478,7 @@ class InfoTagMusic:
         @python_v19 New function added.
         """
         return ""
-    
+
     def getMusicBrainzAlbumArtistID(self) -> List[str]:
         """
         Returns the MusicBrainz Release Artist IDs from music info tag (if present).
@@ -487,7 +488,7 @@ class InfoTagMusic:
         @python_v19 New function added.
         """
         return [""]
-    
+
     def setDbId(self, dbId: int, type: str) -> None:
         """
         Set the database identifier of the music item.
@@ -498,7 +499,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setURL(self, url: str) -> None:
         """
         Set the URL of the music item.
@@ -508,7 +509,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setMediaType(self, mediaType: str) -> None:
         """
         Set the media type of the music item.
@@ -518,7 +519,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setTrack(self, track: int) -> None:
         """
         Set the track number of the song.
@@ -528,7 +529,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setDisc(self, disc: int) -> None:
         """
         Set the disc number of the song.
@@ -538,7 +539,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setDuration(self, duration: int) -> None:
         """
         Set the duration of the song.
@@ -548,7 +549,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setYear(self, year: int) -> None:
         """
         Set the year of the music item.
@@ -558,7 +559,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setReleaseDate(self, releaseDate: str) -> None:
         """
         Set the release date of the music item.
@@ -568,7 +569,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setListeners(self, listeners: int) -> None:
         """
         Set the number of listeners of the music item.
@@ -578,7 +579,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setPlayCount(self, playcount: int) -> None:
         """
         Set the playcount of the music item.
@@ -588,7 +589,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setGenres(self, genres: List[str]) -> None:
         """
         Set the genres of the music item.
@@ -598,7 +599,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setAlbum(self, album: str) -> None:
         """
         Set the album of the music item.
@@ -608,7 +609,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setArtist(self, artist: str) -> None:
         """
         Set the artist(s) of the music item.
@@ -618,7 +619,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setAlbumArtist(self, albumArtist: str) -> None:
         """
         Set the album artist(s) of the music item.
@@ -628,7 +629,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setTitle(self, title: str) -> None:
         """
         Set the title of the music item.
@@ -638,7 +639,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setRating(self, rating: float) -> None:
         """
         Set the rating of the music item.
@@ -648,7 +649,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setUserRating(self, userrating: int) -> None:
         """
         Set the user rating of the music item.
@@ -658,7 +659,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setLyrics(self, lyrics: str) -> None:
         """
         Set the lyrics of the song.
@@ -668,7 +669,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setLastPlayed(self, lastPlayed: str) -> None:
         """
         Set the last played date of the music item.
@@ -678,7 +679,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setMusicBrainzTrackID(self, musicBrainzTrackID: str) -> None:
         """
         Set the MusicBrainz track ID of the song.
@@ -688,7 +689,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setMusicBrainzArtistID(self, musicBrainzArtistID: List[str]) -> None:
         """
         Set the MusicBrainz artist IDs of the music item.
@@ -698,7 +699,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setMusicBrainzAlbumID(self, musicBrainzAlbumID: str) -> None:
         """
         Set the MusicBrainz album ID of the music item.
@@ -708,7 +709,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setMusicBrainzReleaseGroupID(self, musicBrainzReleaseGroupID: str) -> None:
         """
         Set the MusicBrainz release group ID of the music item.
@@ -718,7 +719,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setMusicBrainzAlbumArtistID(self, musicBrainzAlbumArtistID: List[str]) -> None:
         """
         Set the MusicBrainz album artist IDs of the music item.
@@ -728,7 +729,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
     def setComment(self, comment: str) -> None:
         """
         Set the comment of the music item.
@@ -738,7 +739,7 @@ class InfoTagMusic:
         @python_v20 New function added.
         """
         pass
-    
+
 
 class InfoTagPicture:
     """
@@ -752,15 +753,15 @@ class InfoTagPicture:
 
         ...
         tag = item.getPictureInfoTag()
-        
+
         datetime_taken  = tag.getDateTimeTaken()
         tag.setResolution(1920, 1080)
         ...
     """
-    
+
     def __init__(self, offscreen: bool = False) -> None:
         pass
-    
+
     def getResolution(self) -> str:
         """
         Get the resolution of the picture in the format "w x h".
@@ -770,18 +771,18 @@ class InfoTagPicture:
         @python_v20 New function added.
         """
         return ""
-    
+
     def setResolution(self, width: int, height: int) -> None:
         """
         Sets the resolution of the picture.
 
         :param width: int - Width of the picture in pixels.
         :param height: int - Height of the picture in pixels.
-        
+
         @python_v20 New function added.
         """
         pass
-    
+
     def setDateTimeTaken(self, datetimetaken: str) -> None:
         """
         Sets the date and time at which the picture was taken in W3C format. The
@@ -807,7 +808,7 @@ class InfoTagPicture:
         @python_v20 New function added.
         """
         pass
-    
+
 
 class InfoTagRadioRDS:
     """
@@ -824,15 +825,15 @@ class InfoTagRadioRDS:
 
         ...
         tag = xbmc.Player().getRadioRDSInfoTag()
-        
+
         title  = tag.getTitle()
         artist = tag.getArtist()
         ...
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def getTitle(self) -> str:
         """
         Title of the item on the air; i.e. song title.
@@ -840,7 +841,7 @@ class InfoTagRadioRDS:
         :return: Title
         """
         return ""
-    
+
     def getBand(self) -> str:
         """
         Band of the item on air.
@@ -848,7 +849,7 @@ class InfoTagRadioRDS:
         :return: Band
         """
         return ""
-    
+
     def getArtist(self) -> str:
         """
         Artist of the item on air.
@@ -856,7 +857,7 @@ class InfoTagRadioRDS:
         :return: Artist
         """
         return ""
-    
+
     def getComposer(self) -> str:
         """
         Get the Composer of the music.
@@ -864,7 +865,7 @@ class InfoTagRadioRDS:
         :return: Composer
         """
         return ""
-    
+
     def getConductor(self) -> str:
         """
         Get the Conductor of the Band.
@@ -872,7 +873,7 @@ class InfoTagRadioRDS:
         :return: Conductor
         """
         return ""
-    
+
     def getAlbum(self) -> str:
         """
         Album of item on air.
@@ -880,7 +881,7 @@ class InfoTagRadioRDS:
         :return: Album name
         """
         return ""
-    
+
     def getComment(self) -> str:
         """
         Get Comment text from channel.
@@ -888,7 +889,7 @@ class InfoTagRadioRDS:
         :return: Comment
         """
         return ""
-    
+
     def getAlbumTrackNumber(self) -> int:
         """
         Get the album track number of currently sended music.
@@ -896,7 +897,7 @@ class InfoTagRadioRDS:
         :return: Track Number
         """
         return 0
-    
+
     def getInfoNews(self) -> str:
         """
         Get News informations.
@@ -904,7 +905,7 @@ class InfoTagRadioRDS:
         :return: News Information
         """
         return ""
-    
+
     def getInfoNewsLocal(self) -> str:
         """
         Get Local news informations.
@@ -912,7 +913,7 @@ class InfoTagRadioRDS:
         :return: Local News Information
         """
         return ""
-    
+
     def getInfoSport(self) -> str:
         """
         Get Sport informations.
@@ -920,7 +921,7 @@ class InfoTagRadioRDS:
         :return: Sport Information
         """
         return ""
-    
+
     def getInfoStock(self) -> str:
         """
         Get Stock informations.
@@ -928,7 +929,7 @@ class InfoTagRadioRDS:
         :return: Stock Information
         """
         return ""
-    
+
     def getInfoWeather(self) -> str:
         """
         Get Weather informations.
@@ -936,7 +937,7 @@ class InfoTagRadioRDS:
         :return: Weather Information
         """
         return ""
-    
+
     def getInfoHoroscope(self) -> str:
         """
         Get Horoscope informations.
@@ -944,7 +945,7 @@ class InfoTagRadioRDS:
         :return: Horoscope Information
         """
         return ""
-    
+
     def getInfoCinema(self) -> str:
         """
         Get Cinema informations.
@@ -952,7 +953,7 @@ class InfoTagRadioRDS:
         :return: Cinema Information
         """
         return ""
-    
+
     def getInfoLottery(self) -> str:
         """
         Get Lottery informations.
@@ -960,7 +961,7 @@ class InfoTagRadioRDS:
         :return: Lottery Information
         """
         return ""
-    
+
     def getInfoOther(self) -> str:
         """
         Get other informations.
@@ -968,7 +969,7 @@ class InfoTagRadioRDS:
         :return: Other Information
         """
         return ""
-    
+
     def getEditorialStaff(self) -> str:
         """
         Get Editorial Staff names.
@@ -976,7 +977,7 @@ class InfoTagRadioRDS:
         :return: Editorial Staff
         """
         return ""
-    
+
     def getProgStation(self) -> str:
         """
         Name describing station.
@@ -984,7 +985,7 @@ class InfoTagRadioRDS:
         :return: Program Station
         """
         return ""
-    
+
     def getProgStyle(self) -> str:
         """
         The the radio channel style currently used.
@@ -992,7 +993,7 @@ class InfoTagRadioRDS:
         :return: Program Style
         """
         return ""
-    
+
     def getProgHost(self) -> str:
         """
         Host of current radio show.
@@ -1000,7 +1001,7 @@ class InfoTagRadioRDS:
         :return: Program Host
         """
         return ""
-    
+
     def getProgWebsite(self) -> str:
         """
         Link to URL (web page) for radio station homepage.
@@ -1008,7 +1009,7 @@ class InfoTagRadioRDS:
         :return: Program Website
         """
         return ""
-    
+
     def getProgNow(self) -> str:
         """
         Current radio program show.
@@ -1016,7 +1017,7 @@ class InfoTagRadioRDS:
         :return: Program Now
         """
         return ""
-    
+
     def getProgNext(self) -> str:
         """
         Next program show.
@@ -1024,7 +1025,7 @@ class InfoTagRadioRDS:
         :return: Program Next
         """
         return ""
-    
+
     def getPhoneHotline(self) -> str:
         """
         Telephone number of the radio station's hotline.
@@ -1032,7 +1033,7 @@ class InfoTagRadioRDS:
         :return: Phone Hotline
         """
         return ""
-    
+
     def getEMailHotline(self) -> str:
         """
         Email address of the radio station's studio.
@@ -1040,7 +1041,7 @@ class InfoTagRadioRDS:
         :return: EMail Hotline
         """
         return ""
-    
+
     def getPhoneStudio(self) -> str:
         """
         Telephone number of the radio station's studio.
@@ -1048,7 +1049,7 @@ class InfoTagRadioRDS:
         :return: Phone Studio
         """
         return ""
-    
+
     def getEMailStudio(self) -> str:
         """
         Email address of radio station studio.
@@ -1056,7 +1057,7 @@ class InfoTagRadioRDS:
         :return: EMail Studio
         """
         return ""
-    
+
     def getSMSStudio(self) -> str:
         """
         SMS (Text Messaging) number for studio.
@@ -1064,7 +1065,7 @@ class InfoTagRadioRDS:
         :return: SMS Studio
         """
         return ""
-    
+
 
 class Actor:
     """
@@ -1080,13 +1081,13 @@ class Actor:
         actor = xbmc.Actor('Sean Connery', 'James Bond', order=1)
         ...
     """
-    
+
     def __init__(self, name: str = "",
                  role: str = "",
                  order: int = -1,
                  thumbnail: str = "") -> None:
         pass
-    
+
     def getName(self) -> str:
         """
         Get the name of the actor.
@@ -1096,7 +1097,7 @@ class Actor:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getRole(self) -> str:
         """
         Get the role of the actor in the specific video item.
@@ -1106,7 +1107,7 @@ class Actor:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getOrder(self) -> int:
         """
         Get the order of the actor in the cast of the specific video item.
@@ -1116,7 +1117,7 @@ class Actor:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getThumbnail(self) -> str:
         """
         Get the path / URL to the thumbnail of the actor.
@@ -1126,7 +1127,7 @@ class Actor:
         @python_v20 New function added.
         """
         return ""
-    
+
     def setName(self, name: str) -> None:
         """
         Set the name of the actor.
@@ -1136,7 +1137,7 @@ class Actor:
         @python_v20 New function added.
         """
         pass
-    
+
     def setRole(self, role: str) -> None:
         """
         Set the role of the actor in the specific video item.
@@ -1146,7 +1147,7 @@ class Actor:
         @python_v20 New function added.
         """
         pass
-    
+
     def setOrder(self, order: int) -> None:
         """
         Set the order of the actor in the cast of the specific video item.
@@ -1156,7 +1157,7 @@ class Actor:
         @python_v20 New function added.
         """
         pass
-    
+
     def setThumbnail(self, thumbnail: str) -> None:
         """
         Set the path / URL to the thumbnail of the actor.
@@ -1166,7 +1167,7 @@ class Actor:
         @python_v20 New function added.
         """
         pass
-    
+
 
 class VideoStreamDetail:
     """
@@ -1183,7 +1184,7 @@ class VideoStreamDetail:
         videostream = xbmc.VideoStreamDetail(1920, 1080, language='English')
         ...
     """
-    
+
     def __init__(self, width: int = 0,
                  height: int = 0,
                  aspect: float = 0.0,
@@ -1193,7 +1194,7 @@ class VideoStreamDetail:
                  language: str = "",
                  hdrType: str = "") -> None:
         pass
-    
+
     def getWidth(self) -> int:
         """
         Get the width of the video stream in pixel.
@@ -1203,7 +1204,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getHeight(self) -> int:
         """
         Get the height of the video stream in pixel.
@@ -1213,7 +1214,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getAspect(self) -> float:
         """
         Get the aspect ratio of the video stream.
@@ -1223,7 +1224,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return 0.0
-    
+
     def getDuration(self) -> int:
         """
         Get the duration of the video stream in seconds.
@@ -1233,7 +1234,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getCodec(self) -> str:
         """
         Get the codec of the stream.
@@ -1243,7 +1244,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getStereoMode(self) -> str:
         """
         Get the stereo mode of the video stream.
@@ -1253,7 +1254,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getLanguage(self) -> str:
         """
         Get the language of the stream.
@@ -1263,7 +1264,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getHDRType(self) -> str:
         """
         Get the HDR type of the stream.
@@ -1273,7 +1274,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def setWidth(self, width: int) -> None:
         """
         Set the width of the video stream in pixel.
@@ -1283,7 +1284,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setHeight(self, height: int) -> None:
         """
         Set the height of the video stream in pixel.
@@ -1293,7 +1294,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setAspect(self, aspect: float) -> None:
         """
         Set the aspect ratio of the video stream.
@@ -1303,7 +1304,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setDuration(self, duration: int) -> None:
         """
         Set the duration of the video stream in seconds.
@@ -1313,7 +1314,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setCodec(self, codec: str) -> None:
         """
         Set the codec of the stream.
@@ -1323,7 +1324,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setStereoMode(self, stereoMode: str) -> None:
         """
         Set the stereo mode of the video stream.
@@ -1333,7 +1334,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setLanguage(self, language: str) -> None:
         """
         Set the language of the stream.
@@ -1343,7 +1344,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setHDRType(self, hdrType: str) -> None:
         """
         Set the HDR type of the stream.
@@ -1354,7 +1355,7 @@ class VideoStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
 
 class AudioStreamDetail:
     """
@@ -1371,12 +1372,12 @@ class AudioStreamDetail:
         audiostream = xbmc.AudioStreamDetail(6, 'DTS', 'English')
         ...
     """
-    
+
     def __init__(self, channels: int = -1,
                  codec: str = "",
                  language: str = "") -> None:
         pass
-    
+
     def getChannels(self) -> int:
         """
         Get the number of channels in the stream.
@@ -1386,7 +1387,7 @@ class AudioStreamDetail:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getCodec(self) -> str:
         """
         Get the codec of the stream.
@@ -1396,7 +1397,7 @@ class AudioStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getLanguage(self) -> str:
         """
         Get the language of the stream.
@@ -1406,7 +1407,7 @@ class AudioStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def setChannels(self, channels: int) -> None:
         """
         Set the number of channels in the stream.
@@ -1416,7 +1417,7 @@ class AudioStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setCodec(self, codec: str) -> None:
         """
         Set the codec of the stream.
@@ -1426,7 +1427,7 @@ class AudioStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
     def setLanguage(self, language: str) -> None:
         """
         Set the language of the stream.
@@ -1436,7 +1437,7 @@ class AudioStreamDetail:
         @python_v20 New function added.
         """
         pass
-    
+
 
 class SubtitleStreamDetail:
     """
@@ -1453,10 +1454,10 @@ class SubtitleStreamDetail:
         subtitlestream = xbmc.SubtitleStreamDetail('English')
         ...
     """
-    
+
     def __init__(self, language: str = "") -> None:
         pass
-    
+
     def getLanguage(self) -> str:
         """
         Get the language of the stream.
@@ -1466,7 +1467,7 @@ class SubtitleStreamDetail:
         @python_v20 New function added.
         """
         return ""
-    
+
     def setLanguage(self, language: str) -> None:
         """
         Set the language of the stream.
@@ -1488,15 +1489,15 @@ class InfoTagVideo:
 
         ...
         tag = xbmc.Player().getVideoInfoTag()
-        
+
         title = tag.getTitle()
         file  = tag.getFile()
         ...
     """
-    
+
     def __init__(self, offscreen: bool = False) -> None:
         pass
-    
+
     def getDbId(self) -> int:
         """
         Get identification number of tag in database
@@ -1506,7 +1507,7 @@ class InfoTagVideo:
         @python_v17 New function added.
         """
         return 0
-    
+
     def getDirector(self) -> str:
         """
         Getfilm director who has made the film (if present).
@@ -1516,7 +1517,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getDirectors()`** instead.
         """
         return ""
-    
+
     def getDirectors(self) -> List[str]:
         """
         Get a list offilm directors who have made the film (if present).
@@ -1526,7 +1527,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return [""]
-    
+
     def getWritingCredits(self) -> str:
         """
         Get the writing credits if present from video info tag.
@@ -1536,7 +1537,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getWriters()`** instead.
         """
         return ""
-    
+
     def getWriters(self) -> List[str]:
         """
         Get the list of writers (if present) from video info tag.
@@ -1546,7 +1547,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return [""]
-    
+
     def getGenre(self) -> str:
         """
         To get theVideo Genre if available.
@@ -1556,7 +1557,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getGenres()`** instead.
         """
         return ""
-    
+
     def getGenres(self) -> List[str]:
         """
         Get the list ofVideo Genres if available.
@@ -1566,7 +1567,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return [""]
-    
+
     def getTagLine(self) -> str:
         """
         Get video tag line if available.
@@ -1574,7 +1575,7 @@ class InfoTagVideo:
         :return: [string] Video tag line
         """
         return ""
-    
+
     def getPlotOutline(self) -> str:
         """
         Get the outline plot of the video if present.
@@ -1582,7 +1583,7 @@ class InfoTagVideo:
         :return: [string] Outline plot
         """
         return ""
-    
+
     def getPlot(self) -> str:
         """
         Get the plot of the video if present.
@@ -1590,7 +1591,7 @@ class InfoTagVideo:
         :return: [string] Plot
         """
         return ""
-    
+
     def getPictureURL(self) -> str:
         """
         Get a picture URL of the video to show as screenshot.
@@ -1598,7 +1599,7 @@ class InfoTagVideo:
         :return: [string] Picture URL
         """
         return ""
-    
+
     def getTitle(self) -> str:
         """
         Get the video title.
@@ -1606,7 +1607,7 @@ class InfoTagVideo:
         :return: [string] Video title
         """
         return ""
-    
+
     def getTVShowTitle(self) -> str:
         """
         Get the video TV show title.
@@ -1616,7 +1617,7 @@ class InfoTagVideo:
         @python_v17 New function added.
         """
         return ""
-    
+
     def getMediaType(self) -> str:
         """
         Get the media type of the video.
@@ -1640,7 +1641,7 @@ class InfoTagVideo:
         @python_v17 New function added.
         """
         return ""
-    
+
     def getVotes(self) -> str:
         """
         Get the video votes if available from video info tag.
@@ -1650,7 +1651,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getVotesAsInt()`** instead.
         """
         return ""
-    
+
     def getVotesAsInt(self, type: str = "") -> int:
         """
         Get the votes of the rating (if available) as an integer.
@@ -1672,7 +1673,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return 0
-    
+
     def getCast(self) -> str:
         """
         To get the cast of the video when available.
@@ -1682,7 +1683,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getActors()`** instead.
         """
         return ""
-    
+
     def getActors(self) -> List[Actor]:
         """
         Get the cast of the video if available.
@@ -1692,7 +1693,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return [Actor()]
-    
+
     def getFile(self) -> str:
         """
         To get the video file name.
@@ -1700,7 +1701,7 @@ class InfoTagVideo:
         :return: [string] File name
         """
         return ""
-    
+
     def getPath(self) -> str:
         """
         To get the path where the video is stored.
@@ -1708,7 +1709,7 @@ class InfoTagVideo:
         :return: [string] Path
         """
         return ""
-    
+
     def getFilenameAndPath(self) -> str:
         """
         To get the full path with filename where the video is stored.
@@ -1718,7 +1719,7 @@ class InfoTagVideo:
         @python_v19 New function added.
         """
         return ""
-    
+
     def getIMDBNumber(self) -> str:
         """
         To get theIMDb number of the video (if present).
@@ -1726,7 +1727,7 @@ class InfoTagVideo:
         :return: [string] IMDb number
         """
         return ""
-    
+
     def getSeason(self) -> int:
         """
         To get season number of a series
@@ -1736,7 +1737,7 @@ class InfoTagVideo:
         @python_v17 New function added.
         """
         return 0
-    
+
     def getEpisode(self) -> int:
         """
         To get episode number of a series
@@ -1746,7 +1747,7 @@ class InfoTagVideo:
         @python_v17 New function added.
         """
         return 0
-    
+
     def getYear(self) -> int:
         """
         Get production year of video if present.
@@ -1754,7 +1755,7 @@ class InfoTagVideo:
         :return: [integer] Production Year
         """
         return 0
-    
+
     def getRating(self, type: str = "") -> float:
         """
         Get the video rating if present as float (double where supported).
@@ -1776,7 +1777,7 @@ class InfoTagVideo:
         @python_v20 Optional ``type`` parameter added.
         """
         return 0.0
-    
+
     def getUserRating(self) -> int:
         """
         Get the user rating if present as integer.
@@ -1784,7 +1785,7 @@ class InfoTagVideo:
         :return: [integer] The user rating of the video
         """
         return 0
-    
+
     def getPlayCount(self) -> int:
         """
         To get the number of plays of the video.
@@ -1792,7 +1793,7 @@ class InfoTagVideo:
         :return: [integer] Play Count
         """
         return 0
-    
+
     def getLastPlayed(self) -> str:
         """
         Get the last played date / time as string.
@@ -1802,7 +1803,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getLastPlayedAsW3C()`** instead.
         """
         return ""
-    
+
     def getLastPlayedAsW3C(self) -> str:
         """
         Get last played datetime as string in W3C format (YYYY-MM-DDThh:mm:ssTZD).
@@ -1812,7 +1813,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getOriginalTitle(self) -> str:
         """
         To get the original title of the video.
@@ -1820,7 +1821,7 @@ class InfoTagVideo:
         :return: [string] Original title
         """
         return ""
-    
+
     def getPremiered(self) -> str:
         """
         To getpremiered date of the video, if available.
@@ -1830,7 +1831,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getPremieredAsW3C()`** instead.
         """
         return ""
-    
+
     def getPremieredAsW3C(self) -> str:
         """
         Getpremiered date as string in W3C format (YYYY-MM-DD).
@@ -1840,7 +1841,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getFirstAired(self) -> str:
         """
         Returns first aired date as string from info tag.
@@ -1850,7 +1851,7 @@ class InfoTagVideo:
         @python_v20 Deprecated. Use **`getFirstAiredAsW3C()`** instead.
         """
         return ""
-    
+
     def getFirstAiredAsW3C(self) -> str:
         """
         Get first aired date as string in W3C format (YYYY-MM-DD).
@@ -1860,7 +1861,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         return ""
-    
+
     def getTrailer(self) -> str:
         """
         To get the path where the trailer is stored.
@@ -1870,7 +1871,7 @@ class InfoTagVideo:
         @python_v17 New function added.
         """
         return ""
-    
+
     def getArtist(self) -> List[str]:
         """
         To get the artist name (for musicvideos)
@@ -1880,7 +1881,7 @@ class InfoTagVideo:
         @python_v18 New function added.
         """
         return [""]
-    
+
     def getAlbum(self) -> str:
         """
         To get the album name (for musicvideos)
@@ -1890,7 +1891,7 @@ class InfoTagVideo:
         @python_v18 New function added.
         """
         return ""
-    
+
     def getTrack(self) -> int:
         """
         To get the track number (for musicvideos)
@@ -1900,7 +1901,7 @@ class InfoTagVideo:
         @python_v18 New function added.
         """
         return 0
-    
+
     def getDuration(self) -> int:
         """
         To get the duration
@@ -1910,7 +1911,7 @@ class InfoTagVideo:
         @python_v18 New function added.
         """
         return 0
-    
+
     def getResumeTime(self) -> float:
         """
         Gets the resume time of the video item.
@@ -2010,7 +2011,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         pass
-    
+
     def setEpisode(self, episode: int) -> None:
         """
         Set the episode number of the episode.
@@ -2020,7 +2021,7 @@ class InfoTagVideo:
         @python_v20 New function added.
         """
         pass
-    
+
     def setSeason(self, season: int) -> None:
         """
         Set the season number of the video item.
@@ -2592,12 +2593,12 @@ class Keyboard:
         text = kb.getText()
         ..
     """
-    
+
     def __init__(self, line: str = "",
                  heading: str = "",
                  hidden: bool = False) -> None:
         pass
-    
+
     def doModal(self, autoclose: int = 0) -> None:
         """
         Show keyboard and wait for user action.
@@ -2612,7 +2613,7 @@ class Keyboard:
             ..
         """
         pass
-    
+
     def setDefault(self, line: str = "") -> None:
         """
         Set the default text entry.
@@ -2626,7 +2627,7 @@ class Keyboard:
             ..
         """
         pass
-    
+
     def setHiddenInput(self, hidden: bool = False) -> None:
         """
         Allows hidden text entry.
@@ -2640,7 +2641,7 @@ class Keyboard:
             ..
         """
         pass
-    
+
     def setHeading(self, heading: str) -> None:
         """
         Set the keyboard heading.
@@ -2654,7 +2655,7 @@ class Keyboard:
             ..
         """
         pass
-    
+
     def getText(self) -> str:
         """
         Returns the user input as a string.
@@ -2673,7 +2674,7 @@ class Keyboard:
             ..
         """
         return ""
-    
+
     def isConfirmed(self) -> bool:
         """
         Returns False if the user cancelled the input.
@@ -2687,7 +2688,7 @@ class Keyboard:
             ..
         """
         return True
-    
+
 
 class Monitor:
     """
@@ -2695,10 +2696,10 @@ class Monitor:
 
     Creates a new monitor to notify addon about changes.
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def onSettingsChanged(self) -> None:
         """
         onSettingsChanged method.
@@ -2706,7 +2707,7 @@ class Monitor:
         Will be called when addon settings are changed
         """
         pass
-    
+
     def onScreensaverActivated(self) -> None:
         """
         onScreensaverActivated method.
@@ -2714,7 +2715,7 @@ class Monitor:
         Will be called when screensaver kicks in
         """
         pass
-    
+
     def onScreensaverDeactivated(self) -> None:
         """
         onScreensaverDeactivated method.
@@ -2722,7 +2723,7 @@ class Monitor:
         Will be called when screensaver goes off
         """
         pass
-    
+
     def onDPMSActivated(self) -> None:
         """
         onDPMSActivated method.
@@ -2730,7 +2731,7 @@ class Monitor:
         Will be called when energysaving/DPMS gets active
         """
         pass
-    
+
     def onDPMSDeactivated(self) -> None:
         """
         onDPMSDeactivated method.
@@ -2738,7 +2739,7 @@ class Monitor:
         Will be called when energysaving/DPMS is turned off
         """
         pass
-    
+
     def onScanStarted(self, library: str) -> None:
         """
         onScanStarted method.
@@ -2752,7 +2753,7 @@ class Monitor:
         @python_v14 New function added.
         """
         pass
-    
+
     def onScanFinished(self, library: str) -> None:
         """
         onScanFinished method.
@@ -2766,7 +2767,7 @@ class Monitor:
         @python_v14 New function added.
         """
         pass
-    
+
     def onCleanStarted(self, library: str) -> None:
         """
         onCleanStarted method.
@@ -2780,7 +2781,7 @@ class Monitor:
         @python_v14 New function added.
         """
         pass
-    
+
     def onCleanFinished(self, library: str) -> None:
         """
         onCleanFinished method.
@@ -2794,7 +2795,7 @@ class Monitor:
         @python_v14 New function added.
         """
         pass
-    
+
     def onNotification(self, sender: str, method: str, data: str) -> None:
         """
         onNotification method.
@@ -2809,7 +2810,7 @@ class Monitor:
         @python_v13 New function added.
         """
         pass
-    
+
     def waitForAbort(self, timeout: float = -1) -> bool:
         """
         Wait for Abort
@@ -2833,7 +2834,7 @@ class Monitor:
             ..
         """
         return True
-    
+
     def abortRequested(self) -> bool:
         """
         Returns True if abort has been requested.
@@ -2843,7 +2844,7 @@ class Monitor:
         @python_v14 New function added.
         """
         return True
-    
+
 
 class Player:
     """
@@ -2857,12 +2858,12 @@ class Player:
         xbmc.Player().play(url, listitem, windowed)
         ...
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def play(self, item: Union[str,  'PlayList'] = "",
-             listitem: Optional['xbmcgui.ListItem'] = None,
+             listitem: Optional[ListItem] = None,
              windowed: bool = False,
              startpos: int = -1) -> None:
         """
@@ -2890,31 +2891,31 @@ class Player:
             ...
         """
         pass
-    
+
     def stop(self) -> None:
         """
         Stop playing.
         """
         pass
-    
+
     def pause(self) -> None:
         """
         Pause or resume playing if already paused.
         """
         pass
-    
+
     def playnext(self) -> None:
         """
         Play next item in playlist.
         """
         pass
-    
+
     def playprevious(self) -> None:
         """
         Play previous item in playlist.
         """
         pass
-    
+
     def playselected(self, selected: int) -> None:
         """
         Play a certain item from the current playlist.
@@ -2922,7 +2923,7 @@ class Player:
         :param selected: Integer - Item to select
         """
         pass
-    
+
     def isPlaying(self) -> bool:
         """
         Check Kodi is playing something.
@@ -2930,7 +2931,7 @@ class Player:
         :return: True if Kodi is playing a file.
         """
         return True
-    
+
     def isPlayingAudio(self) -> bool:
         """
         Check for playing audio.
@@ -2938,7 +2939,7 @@ class Player:
         :return: True if Kodi is playing an audio file.
         """
         return True
-    
+
     def isPlayingVideo(self) -> bool:
         """
         Check for playing video.
@@ -2946,7 +2947,7 @@ class Player:
         :return: True if Kodi is playing a video.
         """
         return True
-    
+
     def isPlayingRDS(self) -> bool:
         """
         Check for playing radio data system (RDS).
@@ -2954,7 +2955,7 @@ class Player:
         :return: True if kodi is playing a radio data system (RDS).
         """
         return True
-    
+
     def isExternalPlayer(self) -> bool:
         """
         Check for external player.
@@ -2964,7 +2965,7 @@ class Player:
         @python_v18 New function added.
         """
         return True
-    
+
     def getPlayingFile(self) -> str:
         """
         Returns the current playing file as a string.
@@ -2977,8 +2978,8 @@ class Player:
         :raises Exception: If player is not playing a file.
         """
         return ""
-    
-    def getPlayingItem(self) -> 'xbmcgui.ListItem':
+
+    def getPlayingItem(self) -> ListItem:
         """
         Returns the current playing item.
 
@@ -2987,9 +2988,8 @@ class Player:
 
         @python_v20 New function added.
         """
-        from xbmcgui import ListItem
         return ListItem()
-    
+
     def getTime(self) -> float:
         """
         Get playing time.
@@ -3000,7 +3000,7 @@ class Player:
         :raises Exception: If player is not playing a file.
         """
         return 0.0
-    
+
     def seekTime(self, seekTime: float) -> None:
         """
         Seek time.
@@ -3012,7 +3012,7 @@ class Player:
         :raises Exception: If player is not playing a file.
         """
         pass
-    
+
     def setSubtitles(self, subtitleFile: str) -> None:
         """
         Set subtitle file and enable subtitles.
@@ -3020,7 +3020,7 @@ class Player:
         :param subtitleFile: File to use as source ofsubtitles
         """
         pass
-    
+
     def showSubtitles(self, bVisible: bool) -> None:
         """
         Enable / disable subtitles.
@@ -3034,7 +3034,7 @@ class Player:
             ...
         """
         pass
-    
+
     def getSubtitles(self) -> str:
         """
         Get subtitle stream name.
@@ -3042,7 +3042,7 @@ class Player:
         :return: Stream name
         """
         return ""
-    
+
     def getAvailableSubtitleStreams(self) -> List[str]:
         """
         Get Subtitle stream names.
@@ -3050,7 +3050,7 @@ class Player:
         :return: `List` of subtitle streams as name
         """
         return [""]
-    
+
     def setSubtitleStream(self, iStream: int) -> None:
         """
         Set Subtitle Stream.
@@ -3064,8 +3064,8 @@ class Player:
             ...
         """
         pass
-    
-    def updateInfoTag(self, item: 'xbmcgui.ListItem') -> None:
+
+    def updateInfoTag(self, item: ListItem) -> None:
         """
         Update info labels for currently playing item.
 
@@ -3084,7 +3084,7 @@ class Player:
             ...
         """
         pass
-    
+
     def getVideoInfoTag(self) -> InfoTagVideo:
         """
         To get video info tag.
@@ -3095,7 +3095,7 @@ class Player:
         :raises Exception: If player is not playing a file or current file is not a movie file.
         """
         return InfoTagVideo()
-    
+
     def getMusicInfoTag(self) -> InfoTagMusic:
         """
         To get music info tag.
@@ -3106,7 +3106,7 @@ class Player:
         :raises Exception: If player is not playing a file or current file is not a music file.
         """
         return InfoTagMusic()
-    
+
     def getRadioRDSInfoTag(self) -> InfoTagRadioRDS:
         """
         To get Radio RDS info tag
@@ -3117,7 +3117,7 @@ class Player:
         :raises Exception: If player is not playing a file or current file is not a rds file.
         """
         return InfoTagRadioRDS()
-    
+
     def getTotalTime(self) -> float:
         """
         To get total playing time.
@@ -3129,7 +3129,7 @@ class Player:
         :raises Exception: If player is not playing a file.
         """
         return 0.0
-    
+
     def getAvailableAudioStreams(self) -> List[str]:
         """
         Get Audio stream names
@@ -3137,7 +3137,7 @@ class Player:
         :return: `List` of audio streams as name
         """
         return [""]
-    
+
     def setAudioStream(self, iStream: int) -> None:
         """
         Set Audio Stream.
@@ -3151,7 +3151,7 @@ class Player:
             ...
         """
         pass
-    
+
     def getAvailableVideoStreams(self) -> List[str]:
         """
         Get Video stream names
@@ -3159,7 +3159,7 @@ class Player:
         :return: `List` of video streams as name
         """
         return [""]
-    
+
     def setVideoStream(self, iStream: int) -> None:
         """
         Set Video Stream.
@@ -3173,7 +3173,7 @@ class Player:
             ...
         """
         pass
-    
+
     def onPlayBackStarted(self) -> None:
         """
         onPlayBackStarted method.
@@ -3185,7 +3185,7 @@ class Player:
         playing a media file (i.e, if a stream is available)
         """
         pass
-    
+
     def onAVStarted(self) -> None:
         """
         onAVStarted method.
@@ -3195,7 +3195,7 @@ class Player:
         @python_v18 New function added.
         """
         pass
-    
+
     def onAVChange(self) -> None:
         """
         onAVChange method.
@@ -3206,7 +3206,7 @@ class Player:
         @python_v18 New function added.
         """
         pass
-    
+
     def onPlayBackEnded(self) -> None:
         """
         onPlayBackEnded method.
@@ -3214,7 +3214,7 @@ class Player:
         Will be called when Kodi stops playing a file.
         """
         pass
-    
+
     def onPlayBackStopped(self) -> None:
         """
         onPlayBackStopped method.
@@ -3222,7 +3222,7 @@ class Player:
         Will be called when user stops Kodi playing a file.
         """
         pass
-    
+
     def onPlayBackError(self) -> None:
         """
         onPlayBackError method.
@@ -3230,7 +3230,7 @@ class Player:
         Will be called when playback stops due to an error.
         """
         pass
-    
+
     def onPlayBackPaused(self) -> None:
         """
         onPlayBackPaused method.
@@ -3238,7 +3238,7 @@ class Player:
         Will be called when user pauses a playing file.
         """
         pass
-    
+
     def onPlayBackResumed(self) -> None:
         """
         onPlayBackResumed method.
@@ -3246,7 +3246,7 @@ class Player:
         Will be called when user resumes a paused file.
         """
         pass
-    
+
     def onQueueNextItem(self) -> None:
         """
         onQueueNextItem method.
@@ -3254,7 +3254,7 @@ class Player:
         Will be called when user queues the next item.
         """
         pass
-    
+
     def onPlayBackSpeedChanged(self, speed: int) -> None:
         """
         onPlayBackSpeedChanged method.
@@ -3268,7 +3268,7 @@ class Player:
             speed.
         """
         pass
-    
+
     def onPlayBackSeek(self, time: int, seekOffset: int) -> None:
         """
         onPlayBackSeek method.
@@ -3279,7 +3279,7 @@ class Player:
         :param seekOffset: [integer] ?
         """
         pass
-    
+
     def onPlayBackSeekChapter(self, chapter: int) -> None:
         """
         onPlayBackSeekChapter method.
@@ -3289,7 +3289,7 @@ class Player:
         :param chapter: [integer] Chapter to seek to
         """
         pass
-    
+
 
 class PlayList:
     """
@@ -3299,12 +3299,12 @@ class PlayList:
 
     :param playList: [integer] To define the stream type
 
-    ===== =================== =================================== 
-    Value Integer String      Description                         
-    ===== =================== =================================== 
-    0     xbmc.PLAYLIST_MUSIC Playlist for music files or streams 
-    1     xbmc.PLAYLIST_VIDEO Playlist for video files or streams 
-    ===== =================== =================================== 
+    ===== =================== ===================================
+    Value Integer String      Description
+    ===== =================== ===================================
+    0     xbmc.PLAYLIST_MUSIC Playlist for music files or streams
+    1     xbmc.PLAYLIST_VIDEO Playlist for video files or streams
+    ===== =================== ===================================
 
     Example::
 
@@ -3312,10 +3312,10 @@ class PlayList:
         play=xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
         ...
     """
-    
+
     def __init__(self, playList: int) -> None:
         pass
-    
+
     def getPlayListId(self) -> int:
         """
         Get the `PlayList` Identifier
@@ -3323,9 +3323,9 @@ class PlayList:
         :return: Id as an integer.
         """
         return 0
-    
+
     def add(self, url: str,
-            listitem: Optional['xbmcgui.ListItem'] = None,
+            listitem: Optional[ListItem] = None,
             index: int = -1) -> None:
         """
         Adds a new file to the playlist.
@@ -3350,7 +3350,7 @@ class PlayList:
             ..
         """
         pass
-    
+
     def load(self, filename: str) -> bool:
         """
         Load a playlist.
@@ -3362,7 +3362,7 @@ class PlayList:
         :return: False if unable to load playlist
         """
         return True
-    
+
     def remove(self, filename: str) -> None:
         """
         Remove an item with this filename from the playlist.
@@ -3370,13 +3370,13 @@ class PlayList:
         :param filename: The file to remove from list.
         """
         pass
-    
+
     def clear(self) -> None:
         """
         Clear all items in the playlist.
         """
         pass
-    
+
     def size(self) -> int:
         """
         Returns the total number of PlayListItems in this playlist.
@@ -3384,19 +3384,19 @@ class PlayList:
         :return: Amount of playlist entries.
         """
         return 0
-    
+
     def shuffle(self) -> None:
         """
         Shuffle the playlist.
         """
         pass
-    
+
     def unshuffle(self) -> None:
         """
         Unshuffle the playlist.
         """
         pass
-    
+
     def getposition(self) -> int:
         """
         Returns the position of the current song in this playlist.
@@ -3404,16 +3404,16 @@ class PlayList:
         :return: Position of the current song
         """
         return 0
-    
+
 
 class RenderCapture:
     """
     **Kodi's render capture.**
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def getWidth(self) -> int:
         """
         Get width
@@ -3424,7 +3424,7 @@ class RenderCapture:
         :return: Width or 0 prior to calling capture
         """
         return 0
-    
+
     def getHeight(self) -> int:
         """
         Get height
@@ -3435,7 +3435,7 @@ class RenderCapture:
         :return: height or 0 prior to calling capture
         """
         return 0
-    
+
     def getAspectRatio(self) -> float:
         """
         Get aspect ratio of currently displayed video.
@@ -3445,7 +3445,7 @@ class RenderCapture:
         This may be called prior to calling `RenderCapture.capture()`.
         """
         return 0.0
-    
+
     def getImageFormat(self) -> str:
         """
         Get image format
@@ -3455,7 +3455,7 @@ class RenderCapture:
         @python_v17 Image will now always be returned in BGRA
         """
         return ""
-    
+
     def getImage(self, msecs: int = 0) -> bytearray:
         """
         Returns captured image as a bytearray.
@@ -3469,7 +3469,7 @@ class RenderCapture:
         @python_v17 Added the option to specify wait time in msec.
         """
         return bytearray()
-    
+
     def capture(self, width: int, height: int) -> None:
         """
         Issue capture request.
@@ -3680,13 +3680,13 @@ def getLanguage(format: int = ENGLISH_NAME, region: bool = False) -> str:
 
     :param format: [opt] format of the returned language string
 
-    ================= ========================================================== 
-    Value             Description                                                
-    ================= ========================================================== 
-    xbmc.ISO_639_1    Two letter code as defined in ISO 639-1                    
-    xbmc.ISO_639_2    Three letter code as defined in ISO 639-2/T or ISO 639-2/B 
-    xbmc.ENGLISH_NAME Full language name in English (default)                    
-    ================= ========================================================== 
+    ================= ==========================================================
+    Value             Description
+    ================= ==========================================================
+    xbmc.ISO_639_1    Two letter code as defined in ISO 639-1
+    xbmc.ISO_639_2    Three letter code as defined in ISO 639-2/T or ISO 639-2/B
+    xbmc.ENGLISH_NAME Full language name in English (default)
+    ================= ==========================================================
 
     :param region: [opt] append the region delimited by "-" of the language (setting) to
         the returned language string
@@ -3724,14 +3724,14 @@ def getDVDState() -> int:
 
     :return: Values for state are:
 
-    ===== ============================== 
-    Value Name                           
-    ===== ============================== 
-    1     xbmc.DRIVE_NOT_READY           
-    16    xbmc.TRAY_OPEN                 
-    64    xbmc.TRAY_CLOSED_NO_MEDIA      
-    96    xbmc.TRAY_CLOSED_MEDIA_PRESENT 
-    ===== ============================== 
+    ===== ==============================
+    Value Name
+    ===== ==============================
+    1     xbmc.DRIVE_NOT_READY
+    16    xbmc.TRAY_OPEN
+    64    xbmc.TRAY_CLOSED_NO_MEDIA
+    96    xbmc.TRAY_CLOSED_MEDIA_PRESENT
+    ===== ==============================
 
     Example::
 
@@ -3982,17 +3982,17 @@ def startServer(iTyp: int, bStart: bool) -> bool:
     :param typ: integer - use SERVER_* constants  Used format of the returned language
         string
 
-    ========================= ====================================================================== 
-    Value                     Description                                                            
-    ========================= ====================================================================== 
-    xbmc.SERVER_WEBSERVER     To control Kodi's builtin webserver                                    
-    xbmc.SERVER_AIRPLAYSERVER AirPlay is a proprietary protocol stack/suite developed by Apple Inc.  
-    xbmc.SERVER_JSONRPCSERVER Control JSON-RPC HTTP/TCP socket-based interface                       
-    xbmc.SERVER_UPNPRENDERER  UPnP client (aka UPnP renderer)                                        
-    xbmc.SERVER_UPNPSERVER    Control built-in UPnP A/V media server (UPnP-server)                   
-    xbmc.SERVER_EVENTSERVER   Set eventServer part that accepts remote device input on all platforms 
-    xbmc.SERVER_ZEROCONF      Control Kodi's Avahi Zeroconf                                          
-    ========================= ====================================================================== 
+    ========================= ======================================================================
+    Value                     Description
+    ========================= ======================================================================
+    xbmc.SERVER_WEBSERVER     To control Kodi's builtin webserver
+    xbmc.SERVER_AIRPLAYSERVER AirPlay is a proprietary protocol stack/suite developed by Apple Inc.
+    xbmc.SERVER_JSONRPCSERVER Control JSON-RPC HTTP/TCP socket-based interface
+    xbmc.SERVER_UPNPRENDERER  UPnP client (aka UPnP renderer)
+    xbmc.SERVER_UPNPSERVER    Control built-in UPnP A/V media server (UPnP-server)
+    xbmc.SERVER_EVENTSERVER   Set eventServer part that accepts remote device input on all platforms
+    xbmc.SERVER_ZEROCONF      Control Kodi's Avahi Zeroconf
+    ========================= ======================================================================
 
     :param bStart: bool - start (True) or stop (False) a server
     :return: bool - True or False
@@ -4060,13 +4060,13 @@ def convertLanguage(language: str, format: int) -> str:
         three letter code (ISO 639-2/T(B)
     :param format: format of the returned language string
 
-    ================= ========================================================== 
-    Value             Description                                                
-    ================= ========================================================== 
-    xbmc.ISO_639_1    Two letter code as defined in ISO 639-1                    
-    xbmc.ISO_639_2    Three letter code as defined in ISO 639-2/T or ISO 639-2/B 
-    xbmc.ENGLISH_NAME Full language name in English (default)                    
-    ================= ========================================================== 
+    ================= ==========================================================
+    Value             Description
+    ================= ==========================================================
+    xbmc.ISO_639_1    Two letter code as defined in ISO 639-1
+    xbmc.ISO_639_2    Three letter code as defined in ISO 639-2/T or ISO 639-2/B
+    xbmc.ENGLISH_NAME Full language name in English (default)
+    ================= ==========================================================
 
     :return: Converted Language string
 

--- a/xbmcaddon.py
+++ b/xbmcaddon.py
@@ -9,8 +9,6 @@ from typing import List, Optional
 __kodistubs__ = True
 
 
-
-
 class Addon:
     """
     **Kodi's addon class.**
@@ -38,10 +36,10 @@ class Addon:
         self.Addon = xbmcaddon.Addon('script.foo.bar')
         ..
     """
-    
+
     def __init__(self, id: Optional[str] = None) -> None:
         pass
-    
+
     def getLocalizedString(self, id: int) -> str:
         """
         Returns an addon's localized 'string'.
@@ -59,7 +57,7 @@ class Addon:
             ..
         """
         return ""
-    
+
     def getSettings(self) -> 'Settings':
         """
         Returns a wrapper around the addon's settings.
@@ -75,7 +73,7 @@ class Addon:
             ..
         """
         return Settings()
-    
+
     def getSetting(self, id: str) -> str:
         """
         Returns the value of a setting as string.
@@ -93,7 +91,7 @@ class Addon:
             ..
         """
         return ""
-    
+
     def getSettingBool(self, id: str) -> bool:
         """
         Returns the value of a setting as a boolean.
@@ -112,7 +110,7 @@ class Addon:
             ..
         """
         return True
-    
+
     def getSettingInt(self, id: str) -> int:
         """
         Returns the value of a setting as an integer.
@@ -131,7 +129,7 @@ class Addon:
             ..
         """
         return 0
-    
+
     def getSettingNumber(self, id: str) -> float:
         """
         Returns the value of a setting as a floating point number.
@@ -150,7 +148,7 @@ class Addon:
             ..
         """
         return 0.0
-    
+
     def getSettingString(self, id: str) -> str:
         """
         Returns the value of a setting as a string.
@@ -169,7 +167,7 @@ class Addon:
             ..
         """
         return ""
-    
+
     def setSetting(self, id: str, value: str) -> None:
         """
         Sets a script setting.
@@ -190,7 +188,7 @@ class Addon:
             ..
         """
         pass
-    
+
     def setSettingBool(self, id: str, value: bool) -> bool:
         """
         Sets a script setting.
@@ -213,7 +211,7 @@ class Addon:
             ..
         """
         return True
-    
+
     def setSettingInt(self, id: str, value: int) -> bool:
         """
         Sets a script setting.
@@ -236,7 +234,7 @@ class Addon:
             ..
         """
         return True
-    
+
     def setSettingNumber(self, id: str, value: float) -> bool:
         """
         Sets a script setting.
@@ -259,7 +257,7 @@ class Addon:
             ..
         """
         return True
-    
+
     def setSettingString(self, id: str, value: str) -> bool:
         """
         Sets a script setting.
@@ -282,7 +280,7 @@ class Addon:
             ..
         """
         return True
-    
+
     def openSettings(self) -> None:
         """
         Opens this scripts settings dialog.
@@ -294,7 +292,7 @@ class Addon:
             ..
         """
         pass
-    
+
     def getAddonInfo(self, id: str) -> str:
         """
         Returns the value of an addon property as a string.
@@ -303,12 +301,12 @@ class Addon:
 
         Choices for the property are
 
-        ====== ========= =========== ========== 
-        author changelog description disclaimer 
-        fanart icon      id          name       
-        path   profile   stars       summary    
-        type   version                          
-        ====== ========= =========== ========== 
+        ====== ========= =========== ==========
+        author changelog description disclaimer
+        fanart icon      id          name
+        path   profile   stars       summary
+        type   version
+        ====== ========= =========== ==========
 
         :return: AddOn property as a string
 
@@ -319,7 +317,7 @@ class Addon:
             ..
         """
         return ""
-    
+
 
 class Settings:
     """
@@ -336,7 +334,7 @@ class Settings:
         settings = xbmcaddon.Addon('id').getSettings()
         ...
     """
-    
+
     def getBool(self, id: str) -> bool:
         """
         Returns the value of a setting as a boolean.
@@ -353,7 +351,7 @@ class Settings:
             ..
         """
         return True
-    
+
     def getInt(self, id: str) -> int:
         """
         Returns the value of a setting as an integer.
@@ -370,7 +368,7 @@ class Settings:
             ..
         """
         return 0
-    
+
     def getNumber(self, id: str) -> float:
         """
         Returns the value of a setting as a floating point number.
@@ -387,7 +385,7 @@ class Settings:
             ..
         """
         return 0.0
-    
+
     def getString(self, id: str) -> str:
         """
         Returns the value of a setting as a unicode string.
@@ -404,7 +402,7 @@ class Settings:
             ..
         """
         return ""
-    
+
     def getBoolList(self, id: str) -> List[bool]:
         """
         Returns the value of a setting as a list of booleans.
@@ -421,7 +419,7 @@ class Settings:
             ..
         """
         return [True]
-    
+
     def getIntList(self, id: str) -> List[int]:
         """
         Returns the value of a setting as a list of integers.
@@ -438,7 +436,7 @@ class Settings:
             ..
         """
         return [0]
-    
+
     def getNumberList(self, id: str) -> List[float]:
         """
         Returns the value of a setting as a list of floating point numbers.
@@ -455,7 +453,7 @@ class Settings:
             ..
         """
         return [0.0]
-    
+
     def getStringList(self, id: str) -> List[str]:
         """
         Returns the value of a setting as a list of unicode strings.
@@ -472,7 +470,7 @@ class Settings:
             ..
         """
         return [""]
-    
+
     def setBool(self, id: str, value: bool) -> None:
         """
         Sets the value of a setting.
@@ -493,7 +491,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setInt(self, id: str, value: int) -> None:
         """
         Sets the value of a setting.
@@ -514,7 +512,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setNumber(self, id: str, value: float) -> None:
         """
         Sets the value of a setting.
@@ -535,7 +533,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setString(self, id: str, value: str) -> None:
         """
         Sets the value of a setting.
@@ -556,7 +554,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setBoolList(self, id: str, values: List[bool]) -> None:
         """
         Sets the boolean values of a list setting.
@@ -577,7 +575,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setIntList(self, id: str, values: List[int]) -> None:
         """
         Sets the integer values of a list setting.
@@ -598,7 +596,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setNumberList(self, id: str, values: List[float]) -> None:
         """
         Sets the floating point values of a list setting.
@@ -619,7 +617,7 @@ class Settings:
             ..
         """
         pass
-    
+
     def setStringList(self, id: str, values: List[str]) -> None:
         """
         Sets the string values of a list setting.

--- a/xbmcdrm.py
+++ b/xbmcdrm.py
@@ -52,12 +52,12 @@ class CryptoSession:
         crypto_session = xbmcdrm.CryptoSession(uuid_widevine, 'AES/CBC/NoPadding', 'HmacSHA256')
         ..
     """
-    
+
     def __init__(self, UUID: str,
                  cipherAlgorithm: str,
                  macAlgorithm: str) -> None:
         pass
-    
+
     def GetKeyRequest(self, init: Union[str, bytes, bytearray],
                       mimeType: str,
                       offlineKey: bool,
@@ -89,7 +89,7 @@ class CryptoSession:
         @python_v19 With python 3 the init param must be a bytearray instead of byte.
         """
         return bytearray()
-    
+
     def GetPropertyString(self, name: str) -> str:
         """
         Request a system specific property value of the DRM system.
@@ -100,7 +100,7 @@ class CryptoSession:
         @python_v18 New function added.
         """
         return ""
-    
+
     def ProvideKeyResponse(self, response: Union[str, bytes, bytearray]) -> str:
         """
         Provide a key response
@@ -117,7 +117,7 @@ class CryptoSession:
         @python_v19 With python 3 the response argument must be a bytearray instead of byte.
         """
         return ""
-    
+
     def RemoveKeys(self) -> None:
         """
         Removes all keys currently loaded in a session.
@@ -125,7 +125,7 @@ class CryptoSession:
         @python_v18 New function added.
         """
         pass
-    
+
     def RestoreKeys(self, keySetId: str) -> None:
         """
         Restores session keys stored during previous `ProvideKeyResponse` call.
@@ -136,7 +136,7 @@ class CryptoSession:
         @python_v18 New function added.
         """
         pass
-    
+
     def SetPropertyString(self, name: str, value: str) -> None:
         """
         Set a system specific property value in the DRM system.
@@ -147,7 +147,7 @@ class CryptoSession:
         @python_v18 New function added.
         """
         pass
-    
+
     def Decrypt(self, cipherKeyId: Union[str, bytes, bytearray],
                 input: Union[str, bytes, bytearray],
                 iv: Union[str, bytes, bytearray]) -> bytearray:
@@ -164,7 +164,7 @@ class CryptoSession:
         @python_v19 With python 3 all arguments need to be of type bytearray instead of byte.
         """
         return bytearray()
-    
+
     def Encrypt(self, cipherKeyId: Union[str, bytes, bytearray],
                 input: Union[str, bytes, bytearray],
                 iv: Union[str, bytes, bytearray]) -> bytearray:
@@ -181,7 +181,7 @@ class CryptoSession:
         @python_v19 With python 3 all arguments need to be of type bytearray instead of byte.
         """
         return bytearray()
-    
+
     def Sign(self, macKeyId: Union[str, bytes, bytearray],
              message: Union[str, bytes, bytearray]) -> bytearray:
         """
@@ -196,7 +196,7 @@ class CryptoSession:
         @python_v19 With python 3 all arguments need to be of type bytearray instead of byte.
         """
         return bytearray()
-    
+
     def Verify(self, macKeyId: Union[str, bytes, bytearray],
                message: Union[str, bytes, bytearray],
                signature: Union[str, bytes, bytearray]) -> bool:

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -8,6 +8,7 @@ Offers classes and functions that manipulate the Graphical User Interface
 through windows, dialogs, and various control widgets.
 """
 from typing import Union, List, Dict, Tuple, Optional
+from xbmc import InfoTagVideo, InfoTagMusic, InfoTagPicture, InfoTagGame
 
 __kodistubs__ = True
 
@@ -364,7 +365,7 @@ class Control:
 
     def __init__(self) -> None:
         pass
-    
+
     def getId(self) -> int:
         """
         Returns the control's current id as an integer.
@@ -378,7 +379,7 @@ class Control:
             ...
         """
         return 0
-    
+
     def getX(self) -> int:
         """
         Returns the control's current X position.
@@ -392,7 +393,7 @@ class Control:
             ...
         """
         return 0
-    
+
     def getY(self) -> int:
         """
         Returns the control's current Y position.
@@ -406,7 +407,7 @@ class Control:
             ...
         """
         return 0
-    
+
     def getHeight(self) -> int:
         """
         Returns the control's current height as an integer.
@@ -420,7 +421,7 @@ class Control:
             ...
         """
         return 0
-    
+
     def getWidth(self) -> int:
         """
         Returns the control's current width as an integer.
@@ -434,7 +435,7 @@ class Control:
             ...
         """
         return 0
-    
+
     def setEnabled(self, enabled: bool) -> None:
         """
         Sets the control's enabled/disabled state.
@@ -448,7 +449,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setVisible(self, visible: bool) -> None:
         """
         Sets the control's visible/hidden state.
@@ -466,7 +467,7 @@ class Control:
             ...
         """
         pass
-    
+
     def isVisible(self) -> bool:
         """
         Get the control's visible/hidden state with respect to the container/window
@@ -485,7 +486,7 @@ class Control:
             ...
         """
         return True
-    
+
     def setVisibleCondition(self, visible: str,
                             allowHiddenFocus: bool = False) -> None:
         """
@@ -506,7 +507,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setEnableCondition(self, enable: str) -> None:
         """
         Sets the control's enabled condition.
@@ -525,7 +526,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setAnimations(self, eventAttr: List[Tuple[str, str]]) -> None:
         """
         Sets the control's animations.
@@ -546,7 +547,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setPosition(self, x: int, y: int) -> None:
         """
         Sets the controls position.
@@ -564,7 +565,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setWidth(self, width: int) -> None:
         """
         Sets the controls width.
@@ -578,7 +579,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setHeight(self, height: int) -> None:
         """
         Sets the controls height.
@@ -592,7 +593,7 @@ class Control:
             ...
         """
         pass
-    
+
     def setNavigation(self, up: 'Control',
                       down: 'Control',
                       left: 'Control',
@@ -619,7 +620,7 @@ class Control:
             ...
         """
         pass
-    
+
     def controlUp(self, up: 'Control') -> None:
         """
         Sets the controls up navigation.
@@ -639,7 +640,7 @@ class Control:
             ...
         """
         pass
-    
+
     def controlDown(self, control: 'Control') -> None:
         """
         Sets the controls down navigation.
@@ -659,7 +660,7 @@ class Control:
             ...
         """
         pass
-    
+
     def controlLeft(self, control: 'Control') -> None:
         """
         Sets the controls left navigation.
@@ -679,7 +680,7 @@ class Control:
             ...
         """
         pass
-    
+
     def controlRight(self, control: 'Control') -> None:
         """
         Sets the controls right navigation.
@@ -699,7 +700,7 @@ class Control:
             ...
         """
         pass
-    
+
 
 class ControlSpin(Control):
     """
@@ -719,10 +720,10 @@ class ControlSpin(Control):
     **Not working yet**. You can't create this object, it is returned by objects
     like `ControlTextBox` and `ControlList`.
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def setTextures(self, up: str,
                     down: str,
                     upFocus: str,
@@ -747,11 +748,11 @@ class ControlSpin(Control):
 
             ...
             # setTextures(up, down, upFocus, downFocus, upDisabled, downDisabled)
-            
+
             ...
         """
         pass
-    
+
 
 class ControlLabel(Control):
     """
@@ -774,16 +775,16 @@ class ControlLabel(Control):
     :param alignment: [opt] integer - alignment of label  Flags for alignment used as bits
         to have several together:
 
-    ================ ========== ============== 
-    Defination name  Bitflag    Description    
-    ================ ========== ============== 
-    XBFONT_LEFT      0x00000000 Align X left   
-    XBFONT_RIGHT     0x00000001 Align X right  
-    XBFONT_CENTER_X  0x00000002 Align X center 
-    XBFONT_CENTER_Y  0x00000004 Align Y center 
-    XBFONT_TRUNCATED 0x00000008 Truncated text 
-    XBFONT_JUSTIFIED 0x00000010 Justify text   
-    ================ ========== ============== 
+    ================ ========== ==============
+    Defination name  Bitflag    Description
+    ================ ========== ==============
+    XBFONT_LEFT      0x00000000 Align X left
+    XBFONT_RIGHT     0x00000001 Align X right
+    XBFONT_CENTER_X  0x00000002 Align X center
+    XBFONT_CENTER_Y  0x00000004 Align Y center
+    XBFONT_TRUNCATED 0x00000008 Truncated text
+    XBFONT_JUSTIFIED 0x00000010 Justify text
+    ================ ========== ==============
 
     :param hasPath: [opt] bool - True=stores a path / False=no path
     :param angle: [opt] integer - angle of control. (**+** rotates CCW, **-** rotates C)
@@ -796,7 +797,7 @@ class ControlLabel(Control):
         self.label = xbmcgui.ControlLabel(100, 250, 125, 75, 'Status', angle=45)
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -809,7 +810,7 @@ class ControlLabel(Control):
                  hasPath: bool = False,
                  angle: int = 0) -> None:
         pass
-    
+
     def getLabel(self) -> str:
         """
         Returns the text value for this label.
@@ -823,7 +824,7 @@ class ControlLabel(Control):
             ...
         """
         return ""
-    
+
     def setLabel(self, label: str = "",
                  font: Optional[str] = None,
                  textColor: Optional[str] = None,
@@ -850,7 +851,7 @@ class ControlLabel(Control):
             ...
         """
         pass
-    
+
 
 class ControlEdit(Control):
     """
@@ -873,16 +874,16 @@ class ControlEdit(Control):
     :param alignment: [opt] integer - alignment of label  Flags for alignment used as bits
         to have several together:
 
-    ================ ========== ============== 
-    Defination name  Bitflag    Description    
-    ================ ========== ============== 
-    XBFONT_LEFT      0x00000000 Align X left   
-    XBFONT_RIGHT     0x00000001 Align X right  
-    XBFONT_CENTER_X  0x00000002 Align X center 
-    XBFONT_CENTER_Y  0x00000004 Align Y center 
-    XBFONT_TRUNCATED 0x00000008 Truncated text 
-    XBFONT_JUSTIFIED 0x00000010 Justify text   
-    ================ ========== ============== 
+    ================ ========== ==============
+    Defination name  Bitflag    Description
+    ================ ========== ==============
+    XBFONT_LEFT      0x00000000 Align X left
+    XBFONT_RIGHT     0x00000001 Align X right
+    XBFONT_CENTER_X  0x00000002 Align X center
+    XBFONT_CENTER_Y  0x00000004 Align Y center
+    XBFONT_TRUNCATED 0x00000008 Truncated text
+    XBFONT_JUSTIFIED 0x00000010 Justify text
+    ================ ========== ==============
 
     :param focusTexture: [opt] string - filename for focus texture.
     :param noFocusTexture: [opt] string - filename for no focus texture.
@@ -901,7 +902,7 @@ class ControlEdit(Control):
         self.edit = xbmcgui.ControlEdit(100, 250, 125, 75, 'Status')
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -914,7 +915,7 @@ class ControlEdit(Control):
                  focusTexture: Optional[str] = None,
                  noFocusTexture: Optional[str] = None) -> None:
         pass
-    
+
     def setLabel(self, label: str = "",
                  font: Optional[str] = None,
                  textColor: Optional[str] = None,
@@ -941,7 +942,7 @@ class ControlEdit(Control):
             ...
         """
         pass
-    
+
     def getLabel(self) -> str:
         """
         Returns the text heading for this edit control.
@@ -955,7 +956,7 @@ class ControlEdit(Control):
             ...
         """
         return ""
-    
+
     def setText(self, text: str) -> None:
         """
         Sets text value for this edit control.
@@ -969,7 +970,7 @@ class ControlEdit(Control):
             ...
         """
         pass
-    
+
     def getText(self) -> str:
         """
         Returns the text value for this edit control.
@@ -985,26 +986,26 @@ class ControlEdit(Control):
             ...
         """
         return ""
-    
+
     def setType(self, type: int, heading: str) -> None:
         """
         Sets the type of this edit control.
 
         :param type: integer - type of the edit control.
 
-        ============================================= =========================================== 
-        Param                                         Definition                                  
-        ============================================= =========================================== 
-        xbmcgui.INPUT_TYPE_TEXT                       (standard keyboard)                         
-        xbmcgui.INPUT_TYPE_NUMBER                     (format: #)                                 
-        xbmcgui.INPUT_TYPE_DATE                       (format: DD/MM/YYYY)                        
-        xbmcgui.INPUT_TYPE_TIME                       (format: HH:MM)                             
-        xbmcgui.INPUT_TYPE_IPADDRESS                  (format: #.#.#.#)                           
-        xbmcgui.INPUT_TYPE_PASSWORD                   (input is masked)                           
-        xbmcgui.INPUT_TYPE_PASSWORD_MD5               (input is masked, return md5 hash of input) 
-        xbmcgui.INPUT_TYPE_SECONDS                    (format: SS or MM:SS or HH:MM:SS or MM min) 
-        xbmcgui.INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW (numeric input is masked)                   
-        ============================================= =========================================== 
+        ============================================= ===========================================
+        Param                                         Definition
+        ============================================= ===========================================
+        xbmcgui.INPUT_TYPE_TEXT                       (standard keyboard)
+        xbmcgui.INPUT_TYPE_NUMBER                     (format: #)
+        xbmcgui.INPUT_TYPE_DATE                       (format: DD/MM/YYYY)
+        xbmcgui.INPUT_TYPE_TIME                       (format: HH:MM)
+        xbmcgui.INPUT_TYPE_IPADDRESS                  (format: #.#.#.#)
+        xbmcgui.INPUT_TYPE_PASSWORD                   (input is masked)
+        xbmcgui.INPUT_TYPE_PASSWORD_MD5               (input is masked, return md5 hash of input)
+        xbmcgui.INPUT_TYPE_SECONDS                    (format: SS or MM:SS or HH:MM:SS or MM min)
+        xbmcgui.INPUT_TYPE_PASSWORD_NUMBER_VERIFY_NEW (numeric input is masked)
+        ============================================= ===========================================
 
         :param heading: string or unicode - heading that will be used for to numeric or
             keyboard dialog when the edit control is clicked.
@@ -1020,7 +1021,7 @@ class ControlEdit(Control):
             ...
         """
         pass
-    
+
 
 class ControlList(Control):
     """
@@ -1052,16 +1053,16 @@ class ControlList(Control):
     :param alignmentY: [opt] integer - Y-axis alignment of items label  Flags for alignment
         used as bits to have several together:
 
-    ================ ========== ============== 
-    Defination name  Bitflag    Description    
-    ================ ========== ============== 
-    XBFONT_LEFT      0x00000000 Align X left   
-    XBFONT_RIGHT     0x00000001 Align X right  
-    XBFONT_CENTER_X  0x00000002 Align X center 
-    XBFONT_CENTER_Y  0x00000004 Align Y center 
-    XBFONT_TRUNCATED 0x00000008 Truncated text 
-    XBFONT_JUSTIFIED 0x00000010 Justify text   
-    ================ ========== ============== 
+    ================ ========== ==============
+    Defination name  Bitflag    Description
+    ================ ========== ==============
+    XBFONT_LEFT      0x00000000 Align X left
+    XBFONT_RIGHT     0x00000001 Align X right
+    XBFONT_CENTER_X  0x00000002 Align X center
+    XBFONT_CENTER_Y  0x00000004 Align Y center
+    XBFONT_TRUNCATED 0x00000008 Truncated text
+    XBFONT_JUSTIFIED 0x00000010 Justify text
+    ================ ========== ==============
 
     :param shadowColor: [opt] hexstring - color of items label's shadow. (e.g. '0xFF000000')
 
@@ -1077,7 +1078,7 @@ class ControlList(Control):
         self.cList = xbmcgui.ControlList(100, 250, 200, 250, 'font14', space=5)
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -1095,7 +1096,7 @@ class ControlList(Control):
                  _space: int = 2,
                  _alignmentY: int = 4) -> None:
         pass
-    
+
     def addItem(self, item: Union[str,  'ListItem'],
                 sendMessage: bool = True) -> None:
         """
@@ -1110,7 +1111,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def addItems(self, items: List[Union[str,  'ListItem']]) -> None:
         """
         Adds a list of listitems or strings to this list control.
@@ -1129,7 +1130,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def selectItem(self, item: int) -> None:
         """
         Select an item by index number.
@@ -1143,7 +1144,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def removeItem(self, index: int) -> None:
         """
         Remove an item by index number.
@@ -1159,7 +1160,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def reset(self) -> None:
         """
         Clear all ListItems in this control list.
@@ -1198,7 +1199,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def getSpinControl(self) -> Control:
         """
         Returns the associated `ControlSpin` object.
@@ -1213,7 +1214,7 @@ class ControlList(Control):
             ...
         """
         return Control()
-    
+
     def getSelectedPosition(self) -> int:
         """
         Returns the position of the selected item as an integer.
@@ -1228,7 +1229,7 @@ class ControlList(Control):
             ...
         """
         return 0
-    
+
     def getSelectedItem(self) -> 'ListItem':
         """
         Returns the selected item as a `ListItem` object.
@@ -1247,7 +1248,7 @@ class ControlList(Control):
             ...
         """
         return ListItem()
-    
+
     def setImageDimensions(self, imageWidth: int, imageHeight: int) -> None:
         """
         Sets the width/height of items icon or thumbnail.
@@ -1262,7 +1263,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def setSpace(self, space: int) -> None:
         """
         Sets the space between items.
@@ -1276,7 +1277,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def setPageControlVisible(self, visible: bool) -> None:
         """
         Sets the spin control's visible/hidden state.
@@ -1290,7 +1291,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
     def size(self) -> int:
         """
         Returns the total number of items in this list control as an integer.
@@ -1304,7 +1305,7 @@ class ControlList(Control):
             ...
         """
         return 0
-    
+
     def getItemHeight(self) -> int:
         """
         Returns the control's current item height as an integer.
@@ -1318,7 +1319,7 @@ class ControlList(Control):
             ...
         """
         return 0
-    
+
     def getSpace(self) -> int:
         """
         Returns the control's space between items as an integer.
@@ -1332,7 +1333,7 @@ class ControlList(Control):
             ...
         """
         return 0
-    
+
     def getListItem(self, index: int) -> 'ListItem':
         """
         Returns a given `ListItem` in this `List`.
@@ -1349,7 +1350,7 @@ class ControlList(Control):
             ...
         """
         return ListItem()
-    
+
     def setStaticContent(self, items: List['ListItem']) -> None:
         """
         Fills a static list with a list of listitems.
@@ -1366,7 +1367,7 @@ class ControlList(Control):
             ...
         """
         pass
-    
+
 
 class ControlFadeLabel(Control):
     """
@@ -1392,16 +1393,16 @@ class ControlFadeLabel(Control):
     :param alignment: [opt] integer - alignment of label  Flags for alignment used as bits
         to have several together:
 
-    ================ ========== ============== 
-    Defination name  Bitflag    Description    
-    ================ ========== ============== 
-    XBFONT_LEFT      0x00000000 Align X left   
-    XBFONT_RIGHT     0x00000001 Align X right  
-    XBFONT_CENTER_X  0x00000002 Align X center 
-    XBFONT_CENTER_Y  0x00000004 Align Y center 
-    XBFONT_TRUNCATED 0x00000008 Truncated text 
-    XBFONT_JUSTIFIED 0x00000010 Justify text   
-    ================ ========== ============== 
+    ================ ========== ==============
+    Defination name  Bitflag    Description
+    ================ ========== ==============
+    XBFONT_LEFT      0x00000000 Align X left
+    XBFONT_RIGHT     0x00000001 Align X right
+    XBFONT_CENTER_X  0x00000002 Align X center
+    XBFONT_CENTER_Y  0x00000004 Align Y center
+    XBFONT_TRUNCATED 0x00000008 Truncated text
+    XBFONT_JUSTIFIED 0x00000010 Justify text
+    ================ ========== ==============
 
     .. note::
         You can use the above as keywords for arguments and skip certain
@@ -1415,7 +1416,7 @@ class ControlFadeLabel(Control):
         self.fadelabel = xbmcgui.ControlFadeLabel(100, 250, 200, 50, textColor='0xFFFFFFFF')
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -1424,7 +1425,7 @@ class ControlFadeLabel(Control):
                  textColor: Optional[str] = None,
                  _alignment: int = 0) -> None:
         pass
-    
+
     def addLabel(self, label: str) -> None:
         """
         Add a label to this control for scrolling.
@@ -1441,7 +1442,7 @@ class ControlFadeLabel(Control):
             ...
         """
         pass
-    
+
     def setScrolling(self, scroll: bool) -> None:
         """
         Set scrolling. If set to false, the labels won't scroll. Defaults to true.
@@ -1455,7 +1456,7 @@ class ControlFadeLabel(Control):
             ...
         """
         pass
-    
+
 
 class ControlTextBox(Control):
     """
@@ -1501,7 +1502,7 @@ class ControlTextBox(Control):
         textbox.scroll()
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -1509,7 +1510,7 @@ class ControlTextBox(Control):
                  font: Optional[str] = None,
                  textColor: Optional[str] = None) -> None:
         pass
-    
+
     def setText(self, text: str) -> None:
         """
         Sets the text for this textbox.
@@ -1527,7 +1528,7 @@ class ControlTextBox(Control):
             ...
         """
         pass
-    
+
     def getText(self) -> str:
         """
         Returns the text value for this textbox.
@@ -1544,7 +1545,7 @@ class ControlTextBox(Control):
             ...
         """
         return ""
-    
+
     def reset(self) -> None:
         """
         Clear's this textbox.
@@ -1560,7 +1561,7 @@ class ControlTextBox(Control):
             ...
         """
         pass
-    
+
     def scroll(self, id: int) -> None:
         """
         Scrolls to the given position.
@@ -1578,7 +1579,7 @@ class ControlTextBox(Control):
             ...
         """
         pass
-    
+
     def autoScroll(self, delay: int, time: int, repeat: int) -> None:
         """
         Set autoscrolling times.
@@ -1599,7 +1600,7 @@ class ControlTextBox(Control):
             ...
         """
         pass
-    
+
 
 class ControlImage(Control):
     """
@@ -1633,7 +1634,7 @@ class ControlImage(Control):
         self.image = xbmcgui.ControlImage(100, 250, 125, 75, aspectRatio=2)
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -1642,7 +1643,7 @@ class ControlImage(Control):
                  aspectRatio: int = 0,
                  colorDiffuse: Optional[str] = None) -> None:
         pass
-    
+
     def setImage(self, imageFilename: str, useCache: bool = True) -> None:
         """
         Changes the image.
@@ -1661,7 +1662,7 @@ class ControlImage(Control):
             ...
         """
         pass
-    
+
     def setColorDiffuse(self, hexString: str) -> None:
         """
         Changes the images color.
@@ -1676,7 +1677,7 @@ class ControlImage(Control):
             ...
         """
         pass
-    
+
 
 class ControlProgress(Control):
     """
@@ -1726,7 +1727,7 @@ class ControlProgress(Control):
         self.image = xbmcgui.ControlProgress(100, 250, 250, 30, 'special://home/scripts/test.png')
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -1737,7 +1738,7 @@ class ControlProgress(Control):
                  textureright: Optional[str] = None,
                  textureoverlay: Optional[str] = None) -> None:
         pass
-    
+
     def setPercent(self, pct: float) -> None:
         """
         Sets the percentage of the progressbar to show.
@@ -1755,7 +1756,7 @@ class ControlProgress(Control):
             ...
         """
         pass
-    
+
     def getPercent(self) -> float:
         """
         Returns a float of the percent of the progress.
@@ -1770,7 +1771,7 @@ class ControlProgress(Control):
             ...
         """
         return 0.0
-    
+
 
 class ControlButton(Control):
     """
@@ -1795,16 +1796,16 @@ class ControlButton(Control):
     :param alignment: [opt] integer - alignment of label  Flags for alignment used as bits
         to have several together:
 
-    ================ ========== ============== 
-    Defination name  Bitflag    Description    
-    ================ ========== ============== 
-    XBFONT_LEFT      0x00000000 Align X left   
-    XBFONT_RIGHT     0x00000001 Align X right  
-    XBFONT_CENTER_X  0x00000002 Align X center 
-    XBFONT_CENTER_Y  0x00000004 Align Y center 
-    XBFONT_TRUNCATED 0x00000008 Truncated text 
-    XBFONT_JUSTIFIED 0x00000010 Justify text   
-    ================ ========== ============== 
+    ================ ========== ==============
+    Defination name  Bitflag    Description
+    ================ ========== ==============
+    XBFONT_LEFT      0x00000000 Align X left
+    XBFONT_RIGHT     0x00000001 Align X right
+    XBFONT_CENTER_X  0x00000002 Align X center
+    XBFONT_CENTER_Y  0x00000004 Align Y center
+    XBFONT_TRUNCATED 0x00000008 Truncated text
+    XBFONT_JUSTIFIED 0x00000010 Justify text
+    ================ ========== ==============
 
     :param font: [opt] string - font used for label text. (e.g. 'font13')
     :param textColor: [opt] hexstring - color of enabled button's label. (e.g. '0xFFFFFFFF')
@@ -1829,7 +1830,7 @@ class ControlButton(Control):
         self.button = xbmcgui.ControlButton(100, 250, 200, 50, 'Status', font='font14')
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -1847,7 +1848,7 @@ class ControlButton(Control):
                  shadowColor: Optional[str] = None,
                  focusedColor: Optional[str] = None) -> None:
         pass
-    
+
     def setLabel(self, label: str = "",
                  font: Optional[str] = None,
                  textColor: Optional[str] = None,
@@ -1881,7 +1882,7 @@ class ControlButton(Control):
             ...
         """
         pass
-    
+
     def setDisabledColor(self, color: str) -> None:
         """
         Sets this buttons disabled color.
@@ -1896,7 +1897,7 @@ class ControlButton(Control):
             ...
         """
         pass
-    
+
     def getLabel(self) -> str:
         """
         Returns the buttons label as a unicode string.
@@ -1911,7 +1912,7 @@ class ControlButton(Control):
             ...
         """
         return ""
-    
+
     def getLabel2(self) -> str:
         """
         Returns the buttons label2 as a string.
@@ -1926,7 +1927,7 @@ class ControlButton(Control):
             ...
         """
         return ""
-    
+
 
 class ControlGroup(Control):
     """
@@ -1956,10 +1957,10 @@ class ControlGroup(Control):
         self.group = xbmcgui.ControlGroup(100, 250, 125, 75)
         ...
     """
-    
+
     def __init__(self, x: int, y: int, width: int, height: int) -> None:
         pass
-    
+
 
 class ControlRadioButton(Control):
     """
@@ -1988,16 +1989,16 @@ class ControlRadioButton(Control):
     :param alignment: [opt] integer - alignment of label  Flags for alignment used as bits
         to have several together:
 
-    ================ ========== ============== 
-    Defination name  Bitflag    Description    
-    ================ ========== ============== 
-    XBFONT_LEFT      0x00000000 Align X left   
-    XBFONT_RIGHT     0x00000001 Align X right  
-    XBFONT_CENTER_X  0x00000002 Align X center 
-    XBFONT_CENTER_Y  0x00000004 Align Y center 
-    XBFONT_TRUNCATED 0x00000008 Truncated text 
-    XBFONT_JUSTIFIED 0x00000010 Justify text   
-    ================ ========== ============== 
+    ================ ========== ==============
+    Defination name  Bitflag    Description
+    ================ ========== ==============
+    XBFONT_LEFT      0x00000000 Align X left
+    XBFONT_RIGHT     0x00000001 Align X right
+    XBFONT_CENTER_X  0x00000002 Align X center
+    XBFONT_CENTER_Y  0x00000004 Align Y center
+    XBFONT_TRUNCATED 0x00000008 Truncated text
+    XBFONT_JUSTIFIED 0x00000010 Justify text
+    ================ ========== ==============
 
     :param font: [opt] string - font used for label text. (e.g. 'font13')
     :param textColor: [opt] hexstring - color of label when control is enabled.
@@ -2019,7 +2020,7 @@ class ControlRadioButton(Control):
         self.radiobutton = xbmcgui.ControlRadioButton(100, 250, 200, 50, 'Enable', font='font14')
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -2043,7 +2044,7 @@ class ControlRadioButton(Control):
                  disabledOnTexture: Optional[str] = None,
                  disabledOffTexture: Optional[str] = None) -> None:
         pass
-    
+
     def setSelected(self, selected: bool) -> None:
         """
         **Sets the radio buttons's selected status.**
@@ -2062,7 +2063,7 @@ class ControlRadioButton(Control):
             ...
         """
         pass
-    
+
     def isSelected(self) -> bool:
         """
         Returns the radio buttons's selected status.
@@ -2076,7 +2077,7 @@ class ControlRadioButton(Control):
             ...
         """
         return True
-    
+
     def setLabel(self, label: str = "",
                  font: Optional[str] = None,
                  textColor: Optional[str] = None,
@@ -2111,7 +2112,7 @@ class ControlRadioButton(Control):
             ...
         """
         pass
-    
+
     def setRadioDimension(self, x: int,
                           y: int,
                           width: int,
@@ -2136,7 +2137,7 @@ class ControlRadioButton(Control):
             ...
         """
         pass
-    
+
 
 class ControlSlider(Control):
     """
@@ -2173,7 +2174,7 @@ class ControlSlider(Control):
         self.slider = xbmcgui.ControlSlider(100, 250, 350, 40)
         ...
     """
-    
+
     def __init__(self, x: int,
                  y: int,
                  width: int,
@@ -2183,7 +2184,7 @@ class ControlSlider(Control):
                  texturefocus: Optional[str] = None,
                  orientation: int = 1) -> None:
         pass
-    
+
     def getPercent(self) -> float:
         """
         Returns a float of the percent of the slider.
@@ -2197,7 +2198,7 @@ class ControlSlider(Control):
             ...
         """
         return 0.0
-    
+
     def setPercent(self, pct: float) -> None:
         """
         Sets the percent of the slider.
@@ -2211,7 +2212,7 @@ class ControlSlider(Control):
             ...
         """
         pass
-    
+
     def getInt(self) -> int:
         """
         Returns the value of the slider.
@@ -2227,7 +2228,7 @@ class ControlSlider(Control):
             ...
         """
         return 0
-    
+
     def setInt(self, value: int, min: int, delta: int, max: int) -> None:
         """
         Sets the range, value and step size of the slider.
@@ -2246,7 +2247,7 @@ class ControlSlider(Control):
             ...
         """
         pass
-    
+
     def getFloat(self) -> float:
         """
         Returns the value of the slider.
@@ -2262,7 +2263,7 @@ class ControlSlider(Control):
             ...
         """
         return 0.0
-    
+
     def setFloat(self, value: float,
                  min: float,
                  delta: float,
@@ -2284,7 +2285,7 @@ class ControlSlider(Control):
             ...
         """
         pass
-    
+
 
 class Dialog:
     """
@@ -2294,10 +2295,10 @@ class Dialog:
     dialog) is a small window that communicates information to the user and prompts
     them for a response.
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def yesno(self, heading: str,
               message: str,
               nolabel: str = "",
@@ -2319,13 +2320,13 @@ class Dialog:
         :param defaultbutton: [opt] integer - specifies the default focused
             button.(default=DLG_YESNO_NO_BTN)
 
-        ============================ =================================== 
-        Value:                       Description:                        
-        ============================ =================================== 
-        xbmcgui.DLG_YESNO_NO_BTN     Set the "No" button as default.     
-        xbmcgui.DLG_YESNO_YES_BTN    Set the "Yes" button as default.    
-        xbmcgui.DLG_YESNO_CUSTOM_BTN Set the "Custom" button as default. 
-        ============================ =================================== 
+        ============================ ===================================
+        Value:                       Description:
+        ============================ ===================================
+        xbmcgui.DLG_YESNO_NO_BTN     Set the "No" button as default.
+        xbmcgui.DLG_YESNO_YES_BTN    Set the "Yes" button as default.
+        xbmcgui.DLG_YESNO_CUSTOM_BTN Set the "Custom" button as default.
+        ============================ ===================================
 
         :return: Returns True if 'Yes' was pressed, else False.
 
@@ -2347,7 +2348,7 @@ class Dialog:
             ..
         """
         return True
-    
+
     def yesnocustom(self, heading: str,
                     message: str,
                     customlabel: str,
@@ -2372,13 +2373,13 @@ class Dialog:
         :param defaultbutton: [opt] integer - specifies the default focused
             button.(default=DLG_YESNO_NO_BTN)
 
-        ============================ =================================== 
-        Value:                       Description:                        
-        ============================ =================================== 
-        xbmcgui.DLG_YESNO_NO_BTN     Set the "No" button as default.     
-        xbmcgui.DLG_YESNO_YES_BTN    Set the "Yes" button as default.    
-        xbmcgui.DLG_YESNO_CUSTOM_BTN Set the "Custom" button as default. 
-        ============================ =================================== 
+        ============================ ===================================
+        Value:                       Description:
+        ============================ ===================================
+        xbmcgui.DLG_YESNO_NO_BTN     Set the "No" button as default.
+        xbmcgui.DLG_YESNO_YES_BTN    Set the "Yes" button as default.
+        xbmcgui.DLG_YESNO_CUSTOM_BTN Set the "Custom" button as default.
+        ============================ ===================================
 
         :return: Returns the integer value for the selected button (-1:cancelled, 0:no, 1:yes, 2:custom)
 
@@ -2394,7 +2395,7 @@ class Dialog:
             ..
         """
         return 0
-    
+
     def info(self, item: 'ListItem') -> bool:
         """
         **Info dialog**
@@ -2414,7 +2415,7 @@ class Dialog:
             ..
         """
         return True
-    
+
     def select(self, heading: str,
                list: List[Union[str,  'ListItem']],
                autoclose: int = 0,
@@ -2449,7 +2450,7 @@ class Dialog:
             ..
         """
         return 0
-    
+
     def contextmenu(self, list: List[str]) -> int:
         """
         Show a context menu.
@@ -2465,7 +2466,7 @@ class Dialog:
             ..
         """
         return 0
-    
+
     def multiselect(self, heading: str,
                     options: List[Union[str,  'ListItem']],
                     autoclose: int = 0,
@@ -2500,7 +2501,7 @@ class Dialog:
             ..
         """
         return [0]
-    
+
     def ok(self, heading: str, message: str) -> bool:
         """
         **OK dialog**
@@ -2526,7 +2527,7 @@ class Dialog:
             ..
         """
         return True
-    
+
     def textviewer(self, heading: str,
                    text: str,
                    usemono: bool = False) -> None:
@@ -2552,7 +2553,7 @@ class Dialog:
             ..
         """
         pass
-    
+
     def browse(self, type: int,
                heading: str,
                shares: str,
@@ -2571,30 +2572,30 @@ class Dialog:
 
         :param type: integer - the type of browse dialog.
 
-        ===== ============================ 
-        Param Name                         
-        ===== ============================ 
-        0     ShowAndGetDirectory          
-        1     ShowAndGetFile               
-        2     ShowAndGetImage              
-        3     ShowAndGetWriteableDirectory 
-        ===== ============================ 
+        ===== ============================
+        Param Name
+        ===== ============================
+        0     ShowAndGetDirectory
+        1     ShowAndGetFile
+        2     ShowAndGetImage
+        3     ShowAndGetWriteableDirectory
+        ===== ============================
 
         :param heading: string or unicode - dialog heading.
         :param shares: string or unicode - fromsources.xml
 
-        ========== ============================================= 
-        Param      Name                                          
-        ========== ============================================= 
-        "programs" list program addons                           
-        "video"    list video sources                            
-        "music"    list music sources                            
-        "pictures" list picture sources                          
-        "files"    list file sources (added through filemanager) 
-        "games"    list game sources                             
-        "local"    list local drives                             
-        ""         list local drives and network shares          
-        ========== ============================================= 
+        ========== =============================================
+        Param      Name
+        ========== =============================================
+        "programs" list program addons
+        "video"    list video sources
+        "music"    list music sources
+        "pictures" list picture sources
+        "files"    list file sources (added through filemanager)
+        "games"    list game sources
+        "local"    list local drives
+        ""         list local drives and network shares
+        ========== =============================================
 
         :param mask: [opt] string or unicode - '|' separated file mask. (i.e. '.jpg|.png')
         :param useThumbs: [opt] boolean - if True autoswitch to Thumb view if files exist.
@@ -2619,7 +2620,7 @@ class Dialog:
             ..
         """
         return ""
-    
+
     def browseSingle(self, type: int,
                      heading: str,
                      shares: str,
@@ -2637,30 +2638,30 @@ class Dialog:
 
         :param type: integer - the type of browse dialog.
 
-        ===== ============================ 
-        Param Name                         
-        ===== ============================ 
-        0     ShowAndGetDirectory          
-        1     ShowAndGetFile               
-        2     ShowAndGetImage              
-        3     ShowAndGetWriteableDirectory 
-        ===== ============================ 
+        ===== ============================
+        Param Name
+        ===== ============================
+        0     ShowAndGetDirectory
+        1     ShowAndGetFile
+        2     ShowAndGetImage
+        3     ShowAndGetWriteableDirectory
+        ===== ============================
 
         :param heading: string or unicode - dialog heading.
         :param shares: string or unicode - fromsources.xml
 
-        ========== ============================================= 
-        Param      Name                                          
-        ========== ============================================= 
-        "programs" list program addons                           
-        "video"    list video sources                            
-        "music"    list music sources                            
-        "pictures" list picture sources                          
-        "files"    list file sources (added through filemanager) 
-        "games"    list game sources                             
-        "local"    list local drives                             
-        ""         list local drives and network shares          
-        ========== ============================================= 
+        ========== =============================================
+        Param      Name
+        ========== =============================================
+        "programs" list program addons
+        "video"    list video sources
+        "music"    list music sources
+        "pictures" list picture sources
+        "files"    list file sources (added through filemanager)
+        "games"    list game sources
+        "local"    list local drives
+        ""         list local drives and network shares
+        ========== =============================================
 
         :param mask: [opt] string or unicode - '|' separated file mask. (i.e. '.jpg|.png')
         :param useThumbs: [opt] boolean - if True autoswitch to Thumb view if files exist
@@ -2682,7 +2683,7 @@ class Dialog:
             ..
         """
         return ""
-    
+
     def browseMultiple(self, type: int,
                        heading: str,
                        shares: str,
@@ -2701,28 +2702,28 @@ class Dialog:
 
         :param type: integer - the type of browse dialog.
 
-        ===== =============== 
-        Param Name            
-        ===== =============== 
-        1     ShowAndGetFile  
-        2     ShowAndGetImage 
-        ===== =============== 
+        ===== ===============
+        Param Name
+        ===== ===============
+        1     ShowAndGetFile
+        2     ShowAndGetImage
+        ===== ===============
 
         :param heading: string or unicode - dialog heading.
         :param shares: string or unicode - from sources.xml
 
-        ========== ============================================= 
-        Param      Name                                          
-        ========== ============================================= 
-        "programs" list program addons                           
-        "video"    list video sources                            
-        "music"    list music sources                            
-        "pictures" list picture sources                          
-        "files"    list file sources (added through filemanager) 
-        "games"    list game sources                             
-        "local"    list local drives                             
-        ""         list local drives and network shares          
-        ========== ============================================= 
+        ========== =============================================
+        Param      Name
+        ========== =============================================
+        "programs" list program addons
+        "video"    list video sources
+        "music"    list music sources
+        "pictures" list picture sources
+        "files"    list file sources (added through filemanager)
+        "games"    list game sources
+        "local"    list local drives
+        ""         list local drives and network shares
+        ========== =============================================
 
         :param mask: [opt] string or unicode - '|' separated file mask. (i.e. '.jpg|.png')
         :param useThumbs: [opt] boolean - if True autoswitch to Thumb view if files exist
@@ -2743,7 +2744,7 @@ class Dialog:
             ..
         """
         return [""]
-    
+
     def numeric(self, type: int,
                 heading: str,
                 defaultt: str = "",
@@ -2756,15 +2757,15 @@ class Dialog:
 
         :param type: integer - the type of numeric dialog.
 
-        ===== ======================== ============================ 
-        Param Name                     Format                       
-        ===== ======================== ============================ 
+        ===== ======================== ============================
+        Param Name                     Format
+        ===== ======================== ============================
         0     ShowAndGetNumber         (default format: ``#``)
         1     ShowAndGetDate           (default format: ``DD/MM/YYYY``)
         2     ShowAndGetTime           (default format: ``HH:MM``)
         3     ShowAndGetIPAddress      (default format: ``#.#.#.#``)
         4     ShowAndVerifyNewPassword (default format: ``*``)
-        ===== ======================== ============================ 
+        ===== ======================== ============================
 
         :param heading: string or unicode - dialog heading (will be ignored for type 4).
         :param defaultt: [opt] string - default value.
@@ -2783,7 +2784,7 @@ class Dialog:
             ..
         """
         return ""
-    
+
     def notification(self, heading: str,
                      message: str,
                      icon: str = "",
@@ -2816,7 +2817,7 @@ class Dialog:
             ..
         """
         pass
-    
+
     def input(self, heading: str,
               defaultt: str = "",
               type: int = INPUT_ALPHANUM,
@@ -2830,16 +2831,16 @@ class Dialog:
         :param type: [opt] integer - the type of keyboard dialog.
             (default=`xbmcgui.INPUT_ALPHANUM`)
 
-        ============================= =========================================== 
-        Parameter                     Format                                      
-        ============================= =========================================== 
+        ============================= ===========================================
+        Parameter                     Format
+        ============================= ===========================================
         ``xbmcgui.INPUT_ALPHANUM``    (standard keyboard)
         ``xbmcgui.INPUT_NUMERIC``     (format: #)
         ``xbmcgui.INPUT_DATE``        (format: DD/MM/YYYY)
         ``xbmcgui.INPUT_TIME``        (format: HH:MM)
         ``xbmcgui.INPUT_IPADDRESS``   (format: #.#.#.#)
         ``xbmcgui.INPUT_PASSWORD``    (return md5 hash of input, input is masked)
-        ============================= =========================================== 
+        ============================= ===========================================
 
         :param option: [opt] integer - option for the dialog. (see Options below)  Password
             dialog:  ``xbmcgui.PASSWORD_VERIFY`` (verifies an existing
@@ -2859,7 +2860,7 @@ class Dialog:
             ..
         """
         return ""
-    
+
     def colorpicker(self, heading: str,
                     selectedcolor: str = "",
                     colorfile: str = "",
@@ -2902,16 +2903,16 @@ class Dialog:
             ..
         """
         return ""
-    
+
 
 class DialogProgress:
     """
     **Kodi's progress dialog class (Duh!)**
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def create(self, heading: str, message: str = "") -> None:
         """
         Create and show a progress dialog.
@@ -2936,7 +2937,7 @@ class DialogProgress:
             ..
         """
         pass
-    
+
     def update(self, percent: int, message: str = "") -> None:
         """
         Updates the progress dialog.
@@ -2957,7 +2958,7 @@ class DialogProgress:
             ..
         """
         pass
-    
+
     def close(self) -> None:
         """
         Close the progress dialog.
@@ -2969,7 +2970,7 @@ class DialogProgress:
             ..
         """
         pass
-    
+
     def iscanceled(self) -> bool:
         """
         Checks progress is canceled.
@@ -2983,16 +2984,16 @@ class DialogProgress:
             ..
         """
         return True
-    
+
 
 class DialogProgressBG:
     """
     **Kodi's background progress dialog class**
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def deallocating(self) -> None:
         """
         This method is meant to be called from the destructor of the lowest level class.
@@ -3003,7 +3004,7 @@ class DialogProgressBG:
         Any overloading classes need to remember to pass the call up the chain.
         """
         pass
-    
+
     def create(self, heading: str, message: str = "") -> None:
         """
         Create and show a background progress dialog.
@@ -3023,7 +3024,7 @@ class DialogProgressBG:
             ..
         """
         pass
-    
+
     def update(self, percent: int = 0,
                heading: str = "",
                message: str = "") -> None:
@@ -3044,7 +3045,7 @@ class DialogProgressBG:
             ..
         """
         pass
-    
+
     def close(self) -> None:
         """
         Close the background progress dialog
@@ -3056,7 +3057,7 @@ class DialogProgressBG:
             ..
         """
         pass
-    
+
     def isFinished(self) -> bool:
         """
         Checks progress is finished
@@ -3070,19 +3071,19 @@ class DialogProgressBG:
             ..
         """
         return True
-    
+
 
 class ListItem:
     """
     **Selectable window list item.**
     """
-    
+
     def __init__(self, label: str = "",
                  label2: str = "",
                  path: str = "",
                  offscreen: bool = False) -> None:
         pass
-    
+
     def getLabel(self) -> str:
         """
         Returns the listitem label.
@@ -3097,7 +3098,7 @@ class ListItem:
             ...
         """
         return ""
-    
+
     def getLabel2(self) -> str:
         """
         Returns the second listitem label.
@@ -3112,7 +3113,7 @@ class ListItem:
             ...
         """
         return ""
-    
+
     def setLabel(self, label: str) -> None:
         """
         Sets the listitem's label.
@@ -3127,7 +3128,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setLabel2(self, label: str) -> None:
         """
         Sets the listitem's label2.
@@ -3142,7 +3143,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def getDateTime(self) -> str:
         """
         Returns the list item's datetime in W3C format (YYYY-MM-DDThh:mm:ssTZD).
@@ -3159,7 +3160,7 @@ class ListItem:
             ...
         """
         return ""
-    
+
     def setDateTime(self, dateTime: str) -> None:
         """
         Sets the list item's datetime in W3C format. The following formats are
@@ -3192,7 +3193,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setArt(self, dictionary: Dict[str, str]) -> None:
         """
         Sets the listitem's art
@@ -3200,18 +3201,18 @@ class ListItem:
         :param values: dictionary - pairs of ``{ label: value }``. Some default art values
             (any string possible):
 
-        ========= ======================= 
-        Label     Type                    
-        ========= ======================= 
-        thumb     string - image filename 
-        poster    string - image filename 
-        banner    string - image filename 
-        fanart    string - image filename 
-        clearart  string - image filename 
-        clearlogo string - image filename 
-        landscape string - image filename 
-        icon      string - image filename 
-        ========= ======================= 
+        ========= =======================
+        Label     Type
+        ========= =======================
+        thumb     string - image filename
+        poster    string - image filename
+        banner    string - image filename
+        fanart    string - image filename
+        clearart  string - image filename
+        clearlogo string - image filename
+        landscape string - image filename
+        icon      string - image filename
+        ========= =======================
 
         @python_v13 New function added.
 
@@ -3225,7 +3226,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setIsFolder(self, isFolder: bool) -> None:
         """
         Sets if this listitem is a folder.
@@ -3242,7 +3243,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setUniqueIDs(self, dictionary: Dict[str, str],
                      defaultrating: str = "") -> None:
         """
@@ -3253,14 +3254,14 @@ class ListItem:
 
         Some example values (any string possible):
 
-        ===== ====================== 
-        Label Type                   
-        ===== ====================== 
-        imdb  string - uniqueid name 
-        tvdb  string - uniqueid name 
-        tmdb  string - uniqueid name 
-        anidb string - uniqueid name 
-        ===== ====================== 
+        ===== ======================
+        Label Type
+        ===== ======================
+        imdb  string - uniqueid name
+        tvdb  string - uniqueid name
+        tmdb  string - uniqueid name
+        anidb string - uniqueid name
+        ===== ======================
 
         @python_v20 Deprecated. Use **InfoTagVideo.setUniqueIDs()** instead.
 
@@ -3272,7 +3273,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setRating(self, type: str,
                   rating: float,
                   votes: int = 0,
@@ -3286,14 +3287,14 @@ class ListItem:
         :param defaultt: bool - is the default rating?. Default False.  Some example type (any
             string possible):
 
-        ===== ==================== 
-        Label Type                 
-        ===== ==================== 
-        imdb  string - rating type 
-        tvdb  string - rating type 
-        tmdb  string - rating type 
-        anidb string - rating type 
-        ===== ==================== 
+        ===== ====================
+        Label Type
+        ===== ====================
+        imdb  string - rating type
+        tvdb  string - rating type
+        tmdb  string - rating type
+        anidb string - rating type
+        ===== ====================
 
         @python_v20 Deprecated. Use **InfoTagVideo.setRating()** instead.
 
@@ -3305,7 +3306,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def addSeason(self, number: int, name: str = "") -> None:
         """
         Add a season with name to a listitem. It needs at least the season number
@@ -3326,25 +3327,25 @@ class ListItem:
             ...
         """
         pass
-    
+
     def getArt(self, key: str) -> str:
         """
         Returns a listitem art path as a string, similar to an infolabel.
 
         :param key: string - art name.  Some default art values (any string possible):
 
-        ========= =================== 
-        Label     Type                
-        ========= =================== 
-        thumb     string - image path 
-        poster    string - image path 
-        banner    string - image path 
-        fanart    string - image path 
-        clearart  string - image path 
-        clearlogo string - image path 
-        landscape string - image path 
-        icon      string - image path 
-        ========= =================== 
+        ========= ===================
+        Label     Type
+        ========= ===================
+        thumb     string - image path
+        poster    string - image path
+        banner    string - image path
+        fanart    string - image path
+        clearart  string - image path
+        clearlogo string - image path
+        landscape string - image path
+        icon      string - image path
+        ========= ===================
 
         @python_v17 New function added.
 
@@ -3355,7 +3356,7 @@ class ListItem:
             ...
         """
         return ""
-    
+
     def isFolder(self) -> bool:
         """
         Returns whether the item is a folder or not.
@@ -3369,7 +3370,7 @@ class ListItem:
             ...
         """
         return True
-    
+
     def getUniqueID(self, key: str) -> str:
         """
         Returns a listitem uniqueID as a string, similar to an infolabel.
@@ -3377,14 +3378,14 @@ class ListItem:
         :param key: string - uniqueID name.  Some default uniqueID values (any string
             possible):
 
-        ===== ====================== 
-        Label Type                   
-        ===== ====================== 
-        imdb  string - uniqueid name 
-        tvdb  string - uniqueid name 
-        tmdb  string - uniqueid name 
-        anidb string - uniqueid name 
-        ===== ====================== 
+        ===== ======================
+        Label Type
+        ===== ======================
+        imdb  string - uniqueid name
+        tvdb  string - uniqueid name
+        tmdb  string - uniqueid name
+        anidb string - uniqueid name
+        ===== ======================
 
         @python_v20 Deprecated. Use **InfoTagVideo.getUniqueID()** instead.
 
@@ -3395,21 +3396,21 @@ class ListItem:
             ...
         """
         return ""
-    
+
     def getRating(self, key: str) -> float:
         """
         Returns a listitem rating as a float.
 
         :param key: string - rating type.  Some default key values (any string possible):
 
-        ===== ================== 
-        Label Type               
-        ===== ================== 
-        imdb  string - type name 
-        tvdb  string - type name 
-        tmdb  string - type name 
-        anidb string - type name 
-        ===== ================== 
+        ===== ==================
+        Label Type
+        ===== ==================
+        imdb  string - type name
+        tvdb  string - type name
+        tmdb  string - type name
+        anidb string - type name
+        ===== ==================
 
         @python_v20 Deprecated. Use **InfoTagVideo.getRating()** instead.
 
@@ -3420,21 +3421,21 @@ class ListItem:
             ...
         """
         return 0.0
-    
+
     def getVotes(self, key: str) -> int:
         """
         Returns a listitem votes as a integer.
 
         :param key: string - rating type.  Some default key values (any string possible):
 
-        ===== ================== 
-        Label Type               
-        ===== ================== 
-        imdb  string - type name 
-        tvdb  string - type name 
-        tmdb  string - type name 
-        anidb string - type name 
-        ===== ================== 
+        ===== ==================
+        Label Type
+        ===== ==================
+        imdb  string - type name
+        tvdb  string - type name
+        tmdb  string - type name
+        anidb string - type name
+        ===== ==================
 
         @python_v20 Deprecated. Use **InfoTagVideo.getVotesAsInt()** instead.
 
@@ -3445,7 +3446,7 @@ class ListItem:
             ...
         """
         return 0
-    
+
     def select(self, selected: bool) -> None:
         """
         Sets the listitem's selected status.
@@ -3460,7 +3461,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def isSelected(self) -> bool:
         """
         Returns the listitem's selected status.
@@ -3475,7 +3476,7 @@ class ListItem:
             ...
         """
         return True
-    
+
     def setInfo(self, type: str, infoLabels: Dict[str, str]) -> None:
         """
         Sets the listitem's infoLabels.
@@ -3485,14 +3486,14 @@ class ListItem:
 
         **Available types**
 
-        ============ ==================== 
-        Command name Description          
-        ============ ==================== 
-        video        Video information    
-        music        Music information    
-        pictures     Pictures informanion 
-        game         Game information     
-        ============ ==================== 
+        ============ ====================
+        Command name Description
+        ============ ====================
+        video        Video information
+        music        Music information
+        pictures     Pictures informanion
+        game         Game information
+        ============ ====================
 
         .. note::
             To set pictures exif info, prepend ``exif:`` to the label. Exif
@@ -3507,70 +3508,70 @@ class ListItem:
 
         **General Values** (that apply to all types):
 
-        ========== ============================================================================ 
-        Info label Description                                                                  
-        ========== ============================================================================ 
-        count      integer (12) - can be used to store an id for later, or for sorting purposes 
-        size       long (1024) - size in bytes                                                  
-        date       string (d.m.Y / 01.01.2009) - file date                                      
-        ========== ============================================================================ 
+        ========== ============================================================================
+        Info label Description
+        ========== ============================================================================
+        count      integer (12) - can be used to store an id for later, or for sorting purposes
+        size       long (1024) - size in bytes
+        date       string (d.m.Y / 01.01.2009) - file date
+        ========== ============================================================================
 
         **Video Values**:
 
         ============= ==================================================================================================
         Info label    Description
         ============= ==================================================================================================
-        genre         string (Comedy) or list of strings (["Comedy", "Animation", "Drama"])                                                 
-        country       string (Germany) or list of strings (["Germany", "Italy", "France"])                                                  
-        year          integer (2009)                                                                                                        
-        episode       integer (4)                                                                                                           
-        season        integer (1)                                                                                                           
-        sortepisode   integer (4)                                                                                                           
-        sortseason    integer (1)                                                                                                           
-        episodeguide  string (Episode guide)                                                                                                
-        showlink      string (Battlestar Galactica) or list of strings (["Battlestar Galactica", "Caprica"])                                
-        top250        integer (192)                                                                                                         
-        setid         integer (14)                                                                                                          
-        tracknumber   integer (3)                                                                                                           
-        rating        float (6.4) - range is 0..10                                                                                          
-        userrating    integer (9) - range is 1..10 (0 to reset)                                                                             
-        watched       deprecated - use playcount instead                                                                                    
-        playcount     integer (2) - number of times this item has been played                                                               
-        overlay       integer (2) - range is ``0..7``. See Overlay icon types for values                                                     
+        genre         string (Comedy) or list of strings (["Comedy", "Animation", "Drama"])
+        country       string (Germany) or list of strings (["Germany", "Italy", "France"])
+        year          integer (2009)
+        episode       integer (4)
+        season        integer (1)
+        sortepisode   integer (4)
+        sortseason    integer (1)
+        episodeguide  string (Episode guide)
+        showlink      string (Battlestar Galactica) or list of strings (["Battlestar Galactica", "Caprica"])
+        top250        integer (192)
+        setid         integer (14)
+        tracknumber   integer (3)
+        rating        float (6.4) - range is 0..10
+        userrating    integer (9) - range is 1..10 (0 to reset)
+        watched       deprecated - use playcount instead
+        playcount     integer (2) - number of times this item has been played
+        overlay       integer (2) - range is ``0..7``. See Overlay icon types for values
         cast          list (["Michal C. Hall","Jennifer Carpenter"]) - if provided a list of tuples cast will
                       be interpreted as castandrole
-        castandrole   list of tuples ([("Michael C. Hall","Dexter"),("Jennifer Carpenter","Debra")])                                        
-        director      string (Dagur Kari) or list of strings (["Dagur Kari", "Quentin Tarantino", "Chrstopher Nolan"])                      
-        mpaa          string (PG-13)                                                                                                        
-        plot          string (Long Description)                                                                                             
-        plotoutline   string (Short Description)                                                                                            
-        title         string (Big Fan)                                                                                                      
-        originaltitle string (Big Fan)                                                                                                      
-        sorttitle     string (Big Fan)                                                                                                      
-        duration      integer (245) - duration in seconds                                                                                   
-        studio        string (Warner Bros.) or list of strings (["Warner Bros.", "Disney", "Paramount"])                                    
-        tagline       string (An awesome movie) - short description of movie                                                                
+        castandrole   list of tuples ([("Michael C. Hall","Dexter"),("Jennifer Carpenter","Debra")])
+        director      string (Dagur Kari) or list of strings (["Dagur Kari", "Quentin Tarantino", "Chrstopher Nolan"])
+        mpaa          string (PG-13)
+        plot          string (Long Description)
+        plotoutline   string (Short Description)
+        title         string (Big Fan)
+        originaltitle string (Big Fan)
+        sorttitle     string (Big Fan)
+        duration      integer (245) - duration in seconds
+        studio        string (Warner Bros.) or list of strings (["Warner Bros.", "Disney", "Paramount"])
+        tagline       string (An awesome movie) - short description of movie
         writer        string (Robert D. Siegel) or list of strings
                       (["Robert D. Siegel", "Jonathan Nolan", "J.K. Rowling"])
-        tvshowtitle   string (Heroes)                                                                                                       
-        premiered     string (2005-03-04)                                                                                                   
-        status        string (Continuing) - status of a TVshow                                                                              
-        set           string (Batman Collection) - name of the collection                                                                   
-        setoverview   string (All Batman movies) - overview of the collection                                                               
-        tag           string (cult) or list of strings (["cult", "documentary", "best movies"]) - movie tag                                 
-        imdbnumber    string (tt0110293) - IMDb code                                                                                        
-        code          string (101) - Production code                                                                                        
-        aired         string (2008-12-07)                                                                                                   
+        tvshowtitle   string (Heroes)
+        premiered     string (2005-03-04)
+        status        string (Continuing) - status of a TVshow
+        set           string (Batman Collection) - name of the collection
+        setoverview   string (All Batman movies) - overview of the collection
+        tag           string (cult) or list of strings (["cult", "documentary", "best movies"]) - movie tag
+        imdbnumber    string (tt0110293) - IMDb code
+        code          string (101) - Production code
+        aired         string (2008-12-07)
         credits       string (Andy Kaufman) or list of strings (["Dagur Kari", "Quentin Tarantino", "Chrstopher Nolan"])
                       - writing credits
-        lastplayed    string (Y-m-d h:m:s = 2009-04-05 23:16:04)                                                                            
-        album         string (The Joshua Tree)                                                                                              
-        artist        list (['U2'])                                                                                                         
-        votes         string (12345 votes)                                                                                                  
-        path          string (/home/user/movie.avi)                                                                                         
-        trailer       string (/home/user/trailer.avi)                                                                                       
-        dateadded     string (Y-m-d h:m:s = 2009-04-05 23:16:04)                                                                            
-        mediatype     string - "video", "movie", "tvshow", "season", "episode" or "musicvideo"                                              
+        lastplayed    string (Y-m-d h:m:s = 2009-04-05 23:16:04)
+        album         string (The Joshua Tree)
+        artist        list (['U2'])
+        votes         string (12345 votes)
+        path          string (/home/user/movie.avi)
+        trailer       string (/home/user/trailer.avi)
+        dateadded     string (Y-m-d h:m:s = 2009-04-05 23:16:04)
+        mediatype     string - "video", "movie", "tvshow", "season", "episode" or "musicvideo"
         dbid          integer (23) - Only add this for items which are part of the local db. You also need to set
                       the correct 'mediatype'!
         ============= ==================================================================================================
@@ -3578,56 +3579,56 @@ class ListItem:
         **Music Values**:
 
         ======================== =======================================================================================
-        Info label               Description                                                                                                          
+        Info label               Description
         ======================== =======================================================================================
-        tracknumber              integer (8)                                                                                                          
-        discnumber               integer (2)                                                                                                          
-        duration                 integer (245) - duration in seconds                                                                                  
-        year                     integer (1998)                                                                                                       
-        genre                    string (Rock)                                                                                                        
-        album                    string (Pulse)                                                                                                       
-        artist                   string (Muse)                                                                                                        
-        title                    string (American Pie)                                                                                                
-        rating                   float - range is between 0 and 10                                                                                    
-        userrating               integer - range is 1..10                                                                                             
-        lyrics                   string (On a dark desert highway...)                                                                                 
-        playcount                integer (2) - number of times this item has been played                                                              
-        lastplayed               string (Y-m-d h:m:s = 2009-04-05 23:16:04)                                                                           
-        mediatype                string - "music", "song", "album", "artist"                                                                          
+        tracknumber              integer (8)
+        discnumber               integer (2)
+        duration                 integer (245) - duration in seconds
+        year                     integer (1998)
+        genre                    string (Rock)
+        album                    string (Pulse)
+        artist                   string (Muse)
+        title                    string (American Pie)
+        rating                   float - range is between 0 and 10
+        userrating               integer - range is 1..10
+        lyrics                   string (On a dark desert highway...)
+        playcount                integer (2) - number of times this item has been played
+        lastplayed               string (Y-m-d h:m:s = 2009-04-05 23:16:04)
+        mediatype                string - "music", "song", "album", "artist"
         dbid                     integer (23) - Only add this for items which are part of the local db.
                                  You also need to set the correct 'mediatype'!
-        listeners                integer (25614)                                                                                                      
-        musicbrainztrackid       string (cd1de9af-0b71-4503-9f96-9f5efe27923c)                                                                        
-        musicbrainzartistid      string (d87e52c5-bb8d-4da8-b941-9f4928627dc8)                                                                        
-        musicbrainzalbumid       string (24944755-2f68-3778-974e-f572a9e30108)                                                                        
-        musicbrainzalbumartistid string (d87e52c5-bb8d-4da8-b941-9f4928627dc8)                                                                        
-        comment                  string (This is a great song)                                                                                        
+        listeners                integer (25614)
+        musicbrainztrackid       string (cd1de9af-0b71-4503-9f96-9f5efe27923c)
+        musicbrainzartistid      string (d87e52c5-bb8d-4da8-b941-9f4928627dc8)
+        musicbrainzalbumid       string (24944755-2f68-3778-974e-f572a9e30108)
+        musicbrainzalbumartistid string (d87e52c5-bb8d-4da8-b941-9f4928627dc8)
+        comment                  string (This is a great song)
         ======================== =======================================================================================
 
         **Picture Values**:
 
-        =========== ==================================================== 
-        Info label  Description                                          
-        =========== ==================================================== 
-        title       string (In the last summer-1)                        
-        picturepath string (``/home/username/pictures/img001.jpg``)      
-        exif*       string (See kodi_pictures_infotag for valid strings) 
-        =========== ==================================================== 
+        =========== ====================================================
+        Info label  Description
+        =========== ====================================================
+        title       string (In the last summer-1)
+        picturepath string (``/home/username/pictures/img001.jpg``)
+        exif*       string (See kodi_pictures_infotag for valid strings)
+        =========== ====================================================
 
         **Game Values**:
 
-        ========== ============================= 
-        Info label Description                   
-        ========== ============================= 
-        title      string (Super Mario Bros.)    
-        platform   string (Atari 2600)           
-        genres     list (["Action","Strategy"])  
-        publisher  string (Nintendo)             
-        developer  string (Square)               
-        overview   string (Long Description)     
-        year       integer (1980)                
-        gameclient string (game.libretro.fceumm) 
-        ========== ============================= 
+        ========== =============================
+        Info label Description
+        ========== =============================
+        title      string (Super Mario Bros.)
+        platform   string (Atari 2600)
+        genres     list (["Action","Strategy"])
+        publisher  string (Nintendo)
+        developer  string (Square)
+        overview   string (Long Description)
+        year       integer (1980)
+        gameclient string (game.libretro.fceumm)
+        ========== =============================
 
         @python_v14 Added new label **discnumber**.
 
@@ -3653,7 +3654,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setCast(self, actors: List[Dict[str, str]]) -> None:
         """
         Set cast including thumbnails
@@ -3662,14 +3663,14 @@ class ListItem:
 
         Keys:
 
-        ========= ============================================= 
-        Label     Description                                   
-        ========= ============================================= 
-        name      string (Michael C. Hall)                      
-        role      string (Dexter)                               
-        thumbnail string (http://www.someurl.com/someimage.png) 
-        order     integer (1)                                   
-        ========= ============================================= 
+        ========= =============================================
+        Label     Description
+        ========= =============================================
+        name      string (Michael C. Hall)
+        role      string (Dexter)
+        thumbnail string (http://www.someurl.com/someimage.png)
+        order     integer (1)
+        ========= =============================================
 
         @python_v17 New function added.
 
@@ -3683,7 +3684,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setAvailableFanart(self, images: List[Dict[str, str]]) -> None:
         """
         Set available images (needed for video scrapers)
@@ -3692,10 +3693,10 @@ class ListItem:
 
         Keys:
 
-        ======= ========================================================== 
-        Label   Description                                                
-        ======= ========================================================== 
-        image   string (http://www.someurl.com/someimage.png)              
+        ======= ==========================================================
+        Label   Description
+        ======= ==========================================================
+        image   string (http://www.someurl.com/someimage.png)
         preview [opt] string (http://www.someurl.com/somepreviewimage.png)
         colors  [opt] string (either comma separated Kodi hex values
                 ("``FFFFFFFF,DDDDDDDD``") or TVDB RGB Int Triplets
@@ -3713,7 +3714,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def addAvailableArtwork(self, url: str,
                             art_type: str = "",
                             preview: str = "",
@@ -3746,7 +3747,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def addStreamInfo(self, cType: str, dictionary: Dict[str, str]) -> None:
         """
         Add a stream with details.
@@ -3756,33 +3757,33 @@ class ListItem:
 
         Video Values:
 
-        ======== ================= 
-        Label    Description       
-        ======== ================= 
-        codec    string (h264)     
-        aspect   float (1.78)      
-        width    integer (1280)    
-        height   integer (720)     
-        duration integer (seconds) 
-        ======== ================= 
+        ======== =================
+        Label    Description
+        ======== =================
+        codec    string (h264)
+        aspect   float (1.78)
+        width    integer (1280)
+        height   integer (720)
+        duration integer (seconds)
+        ======== =================
 
         Audio Values:
 
-        ======== ============ 
-        Label    Description  
-        ======== ============ 
-        codec    string (dts) 
-        language string (en)  
-        channels integer (2)  
-        ======== ============ 
+        ======== ============
+        Label    Description
+        ======== ============
+        codec    string (dts)
+        language string (en)
+        channels integer (2)
+        ======== ============
 
         Subtitle Values:
 
-        ======== =========== 
-        Label    Description 
-        ======== =========== 
-        language string (en) 
-        ======== =========== 
+        ======== ===========
+        Label    Description
+        ======== ===========
+        language string (en)
+        ======== ===========
 
         @python_v20 Deprecated.
         Use **InfoTagVideo.addVideoStream()**, **InfoTagVideo.addAudioStream()**
@@ -3795,7 +3796,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def addContextMenuItems(self, items: List[Tuple[str, str]],
                             replaceItems: bool = False) -> None:
         """
@@ -3820,7 +3821,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setProperty(self, key: str, value: str) -> None:
         """
         Sets a listitem property, similar to an infolabel.
@@ -3840,19 +3841,19 @@ class ListItem:
         **Internal Properties**
 
         ================== =============================================================================================
-        Key                Description                                                                                                                           
+        Key                Description
         ================== =============================================================================================
-        inputstream        string (inputstream.adaptive) - Set the inputstream add-on that will be used to play the item                                         
-        IsPlayable         string - "true", "false" - Mark the item as playable,**mandatory for playable items **                                                 
-        MimeType           string (application/x-mpegURL) - Set the MimeType of the item before playback                                                         
-        ResumeTime         float (1962.0) - Set the resume point of the item in seconds                                                                          
-        SpecialSort        string - "top", "bottom" - The item will remain at the top or bottom of the current list                                              
-        StartOffset        float (60.0) - Set the offset in seconds at which to start playback of the item                                                       
-        StartPercent       float (15.0) - Set the percentage at which to start playback of the item                                                              
+        inputstream        string (inputstream.adaptive) - Set the inputstream add-on that will be used to play the item
+        IsPlayable         string - "true", "false" - Mark the item as playable,**mandatory for playable items **
+        MimeType           string (application/x-mpegURL) - Set the MimeType of the item before playback
+        ResumeTime         float (1962.0) - Set the resume point of the item in seconds
+        SpecialSort        string - "top", "bottom" - The item will remain at the top or bottom of the current list
+        StartOffset        float (60.0) - Set the offset in seconds at which to start playback of the item
+        StartPercent       float (15.0) - Set the percentage at which to start playback of the item
         StationName        string ("My Station Name") - Used to enforce/override MusicPlayer.StationName infolabel from
                            addons (e.g. in radio addons)
-        TotalTime          float (7848.0) - Set the total time of the item in seconds                                                                            
-        OverrideInfotag    string - "true", "false" - When true will override all info from previous listitem                                                    
+        TotalTime          float (7848.0) - Set the total time of the item in seconds
+        OverrideInfotag    string - "true", "false" - When true will override all info from previous listitem
         ForceResolvePlugin string - "true", "false" - When true ensures that a plugin will always receive callbacks
                            to resolve paths (useful for playlist cases)
         ================== =============================================================================================
@@ -3872,7 +3873,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setProperties(self, dictionary: Dict[str, str]) -> None:
         """
         Sets multiple properties for listitem's
@@ -3889,7 +3890,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def getProperty(self, key: str) -> str:
         """
         Returns a listitem property as a string, similar to an infolabel.
@@ -3912,7 +3913,7 @@ class ListItem:
             ...
         """
         return ""
-    
+
     def setPath(self, path: str) -> None:
         """
         Sets the listitem's path.
@@ -3929,7 +3930,7 @@ class ListItem:
             ...
         """
         pass
-    
+
     def setMimeType(self, mimetype: str) -> None:
         """
         Sets the listitem's mimetype if known.
@@ -3940,7 +3941,7 @@ class ListItem:
         being sent to HTTP servers to figure out file type.
         """
         pass
-    
+
     def setContentLookup(self, enable: bool) -> None:
         """
         Enable or disable content lookup for item.
@@ -3952,7 +3953,7 @@ class ListItem:
         @python_v16 New function added.
         """
         pass
-    
+
     def setSubtitles(self, subtitleFiles: List[str]) -> None:
         """
         Sets subtitles for this listitem.
@@ -3968,7 +3969,7 @@ class ListItem:
         @python_v14 New function added.
         """
         pass
-    
+
     def getPath(self) -> str:
         """
         Returns the path of this listitem.
@@ -3978,8 +3979,8 @@ class ListItem:
         @python_v17 New function added.
         """
         return ""
-    
-    def getVideoInfoTag(self) -> 'xbmc.InfoTagVideo':
+
+    def getVideoInfoTag(self) -> InfoTagVideo:
         """
         Returns the VideoInfoTag for this item.
 
@@ -3989,8 +3990,8 @@ class ListItem:
         """
         from xbmc import InfoTagVideo
         return InfoTagVideo()
-    
-    def getMusicInfoTag(self) -> 'xbmc.InfoTagMusic':
+
+    def getMusicInfoTag(self) -> InfoTagMusic:
         """
         Returns the MusicInfoTag for this item.
 
@@ -4000,8 +4001,8 @@ class ListItem:
         """
         from xbmc import InfoTagMusic
         return InfoTagMusic()
-    
-    def getPictureInfoTag(self) -> 'xbmc.InfoTagPicture':
+
+    def getPictureInfoTag(self) -> InfoTagPicture:
         """
         Returns the InfoTagPicture for this item.
 
@@ -4011,8 +4012,8 @@ class ListItem:
         """
         from xbmc import InfoTagPicture
         return InfoTagPicture()
-    
-    def getGameInfoTag(self) -> 'xbmc.InfoTagGame':
+
+    def getGameInfoTag(self) -> InfoTagGame:
         """
         Returns the InfoTagGame for this item.
 
@@ -4022,7 +4023,7 @@ class ListItem:
         """
         from xbmc import InfoTagGame
         return InfoTagGame()
-    
+
 
 class Action:
     """
@@ -4034,10 +4035,10 @@ class Action:
     The data of this class are always transmitted by callback `Window::onAction` at a
     window.
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
     def getId(self) -> int:
         """
         To get kodi_key_action_ids
@@ -4056,7 +4057,7 @@ class Action:
             ..
         """
         return 0
-    
+
     def getButtonCode(self) -> int:
         """
         Returns the button code for this action.
@@ -4064,7 +4065,7 @@ class Action:
         :return: [integer] button code
         """
         return 0
-    
+
     def getAmount1(self) -> float:
         """
         Returns the first amount of force applied to the thumbstick.
@@ -4072,7 +4073,7 @@ class Action:
         :return: [float] first amount
         """
         return 0.0
-    
+
     def getAmount2(self) -> float:
         """
         Returns the second amount of force applied to the thumbstick.
@@ -4080,7 +4081,7 @@ class Action:
         :return: [float] second amount
         """
         return 0.0
-    
+
 
 class Window:
     """
@@ -4110,10 +4111,10 @@ class Window:
         width = win.getWidth()
         ..
     """
-    
+
     def __init__(self, existingWindowId: int = -1) -> None:
         pass
-    
+
     def show(self) -> None:
         """
         Show this window.
@@ -4127,7 +4128,7 @@ class Window:
             instead.
         """
         pass
-    
+
     def setFocus(self, pControl: Control) -> None:
         """
         Give the supplied control focus.
@@ -4138,7 +4139,7 @@ class Window:
         :raises RuntimeError: If control is not added to a window
         """
         pass
-    
+
     def setFocusId(self, iControlId: int) -> None:
         """
         Gives the control with the supplied focus.
@@ -4148,7 +4149,7 @@ class Window:
         :raises RuntimeError: If control is not added to a window
         """
         pass
-    
+
     def getFocus(self) -> Control:
         """
         Returns the control which is focused.
@@ -4159,7 +4160,7 @@ class Window:
         :raises RuntimeError: If no control has focus
         """
         return Control()
-    
+
     def getFocusId(self) -> int:
         """
         Returns the id of the control which is focused.
@@ -4169,7 +4170,7 @@ class Window:
         :raises RuntimeError: If no control has focus
         """
         return 0
-    
+
     def removeControl(self, pControl: Control) -> None:
         """
         Removes the control from this window.
@@ -4181,7 +4182,7 @@ class Window:
         This will not delete the control. It is only removed from the window.
         """
         pass
-    
+
     def removeControls(self, pControls: List[Control]) -> None:
         """
         Removes a list of controls from this window.
@@ -4194,7 +4195,7 @@ class Window:
         window.
         """
         pass
-    
+
     def getHeight(self) -> int:
         """
         Returns the height of this `Window` instance.
@@ -4204,7 +4205,7 @@ class Window:
         @python_v18 Function changed
         """
         return 0
-    
+
     def getWidth(self) -> int:
         """
         Returns the width of this `Window` instance.
@@ -4214,7 +4215,7 @@ class Window:
         @python_v18 Function changed
         """
         return 0
-    
+
     def setProperty(self, key: str, value: str) -> None:
         """
         Sets a window property, similar to an infolabel.
@@ -4236,7 +4237,7 @@ class Window:
             ..
         """
         pass
-    
+
     def getProperty(self, key: str) -> str:
         """
         Returns a window property as a string, similar to an infolabel.
@@ -4256,7 +4257,7 @@ class Window:
             ..
         """
         return ""
-    
+
     def clearProperty(self, key: str) -> None:
         """
         Clears the specific window property.
@@ -4277,7 +4278,7 @@ class Window:
             ..
         """
         pass
-    
+
     def clearProperties(self) -> None:
         """
         Clears all window properties.
@@ -4290,7 +4291,7 @@ class Window:
             ..
         """
         pass
-    
+
     def close(self) -> None:
         """
         Closes this window.
@@ -4301,13 +4302,13 @@ class Window:
             The window is not deleted with this method.
         """
         pass
-    
+
     def doModal(self) -> None:
         """
         Display this window until `close()` is called.
         """
         pass
-    
+
     def addControl(self, pControl: Control) -> None:
         """
         Add a `Control` to this window.
@@ -4320,29 +4321,29 @@ class Window:
         The next controls can be added to a window atm
 
         ==================== =======================================================================
-        Control-class        Description                                                                                     
+        Control-class        Description
         ==================== =======================================================================
-        `ControlLabel`       Label control to show text                                                                      
-        `ControlFadeLabel`   The fadelabel has multiple labels which it cycles through                                       
-        `ControlTextBox`     To show bigger text field                                                                       
-        `ControlButton`      Brings a button to do some actions                                                              
-        `ControlEdit`        The edit control allows a user to input text in Kodi                                            
+        `ControlLabel`       Label control to show text
+        `ControlFadeLabel`   The fadelabel has multiple labels which it cycles through
+        `ControlTextBox`     To show bigger text field
+        `ControlButton`      Brings a button to do some actions
+        `ControlEdit`        The edit control allows a user to input text in Kodi
         `ControlFadeLabel`   The fade label control is used for displaying multiple pieces of text
                              in the same space in Kodi
-        `ControlList`        Add a list for something like files                                                             
-        `ControlGroup`       Is for a group which brings the others together                                                 
-        `ControlImage`       Controls a image on skin                                                                        
-        `ControlRadioButton` For a radio button which handle boolean values                                                  
-        `ControlProgress`    Progress bar for a performed work or something else                                             
+        `ControlList`        Add a list for something like files
+        `ControlGroup`       Is for a group which brings the others together
+        `ControlImage`       Controls a image on skin
+        `ControlRadioButton` For a radio button which handle boolean values
+        `ControlProgress`    Progress bar for a performed work or something else
         `ControlSlider`      The slider control is used for things where a sliding bar best
                              represents the operation at hand
-        `ControlSpin`        The spin control is used for when a list of options can be chosen                               
+        `ControlSpin`        The spin control is used for when a list of options can be chosen
         `ControlTextBox`     The text box is used for showing a large multipage piece of text
                              in Kodi
         ==================== =======================================================================
         """
         pass
-    
+
     def addControls(self, pControls: List[Control]) -> None:
         """
         Add a list of Controls to this window.
@@ -4354,7 +4355,7 @@ class Window:
         :raises RuntimeError: Should not happen :-)
         """
         pass
-    
+
     def getControl(self, iControlId: int) -> Control:
         """
         Gets the control from this window.
@@ -4370,7 +4371,7 @@ class Window:
             the `Control` functions
         """
         return Control()
-    
+
     def onAction(self, action: Action) -> None:
         """
         **onAction method.**
@@ -4404,7 +4405,7 @@ class Window:
             ..
         """
         pass
-    
+
     def onControl(self, control: Control) -> None:
         """
         **onControl method.**
@@ -4424,7 +4425,7 @@ class Window:
             ..
         """
         pass
-    
+
     def onClick(self, controlId: int) -> None:
         """
         **onClick method.**
@@ -4445,7 +4446,7 @@ class Window:
             ..
         """
         pass
-    
+
     def onDoubleClick(self, controlId: int) -> None:
         """
         **onDoubleClick method.**
@@ -4466,7 +4467,7 @@ class Window:
             ..
         """
         pass
-    
+
     def onFocus(self, controlId: int) -> None:
         """
         **onFocus method.**
@@ -4487,7 +4488,7 @@ class Window:
             ..
         """
         pass
-    
+
     def onInit(self) -> None:
         """
         **onInit method.**
@@ -4505,7 +4506,7 @@ class Window:
             ..
         """
         pass
-    
+
 
 class WindowDialog(Window):
     """
@@ -4528,10 +4529,10 @@ class WindowDialog(Window):
         width = dialog.getWidth()
         ..
     """
-    
+
     def __init__(self) -> None:
         pass
-    
+
 
 class WindowXML(Window):
     """
@@ -4583,14 +4584,14 @@ class WindowXML(Window):
         ...
         </control>
     """
-    
+
     def __init__(self, xmlFilename: str,
                  scriptPath: str,
                  defaultSkin: str = "Default",
                  defaultRes: str = "720p",
                  isMedia: bool = False) -> None:
         pass
-    
+
     def addItem(self, item: Union[str,  ListItem],
                 position: int = 2147483647) -> None:
         """
@@ -4610,7 +4611,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def addItems(self, items: List[Union[str,  ListItem]]) -> None:
         """
         Add a list of items to to the window list.
@@ -4624,7 +4625,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def removeItem(self, position: int) -> None:
         """
         Removes a specified item based on position, from the `Window ``List`.
@@ -4638,7 +4639,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def getCurrentListPosition(self) -> int:
         """
         Gets the current position in the `Window ``List`.
@@ -4650,7 +4651,7 @@ class WindowXML(Window):
             ..
         """
         return 0
-    
+
     def setCurrentListPosition(self, position: int) -> None:
         """
         Set the current position in the `Window ``List`.
@@ -4664,7 +4665,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def getListItem(self, position: int) -> ListItem:
         """
         Returns a given `ListItem` in this `Window ``List`.
@@ -4678,7 +4679,7 @@ class WindowXML(Window):
             ..
         """
         return ListItem()
-    
+
     def getListSize(self) -> int:
         """
         Returns the number of items in this `Window ``List`.
@@ -4690,7 +4691,7 @@ class WindowXML(Window):
             ..
         """
         return 0
-    
+
     def clearList(self) -> None:
         """
         Clear the `Window ``List`.
@@ -4702,7 +4703,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def setContainerProperty(self, strProperty: str, strValue: str) -> None:
         """
         Sets a container property, similar to an infolabel.
@@ -4725,7 +4726,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def setContent(self, strValue: str) -> None:
         """
         Sets the content type of the container.
@@ -4734,32 +4735,32 @@ class WindowXML(Window):
 
         **Available content types**
 
-        =========== ========================================= 
-        Name        Media                                     
-        =========== ========================================= 
-        actors      Videos                                    
-        addons      Addons, Music, Pictures, Programs, Videos 
-        albums      Music, Videos                             
-        artists     Music, Videos                             
-        countries   Music, Videos                             
-        directors   Videos                                    
-        files       Music, Videos                             
-        games       Games                                     
-        genres      Music, Videos                             
-        images      Pictures                                  
-        mixed       Music, Videos                             
-        movies      Videos                                    
-        Musicvideos Music, Videos                             
-        playlists   Music, Videos                             
-        seasons     Videos                                    
-        sets        Videos                                    
-        songs       Music                                     
-        studios     Music, Videos                             
-        tags        Music, Videos                             
-        tvshows     Videos                                    
-        videos      Videos                                    
-        years       Music, Videos                             
-        =========== ========================================= 
+        =========== =========================================
+        Name        Media
+        =========== =========================================
+        actors      Videos
+        addons      Addons, Music, Pictures, Programs, Videos
+        albums      Music, Videos
+        artists     Music, Videos
+        countries   Music, Videos
+        directors   Videos
+        files       Music, Videos
+        games       Games
+        genres      Music, Videos
+        images      Pictures
+        mixed       Music, Videos
+        movies      Videos
+        Musicvideos Music, Videos
+        playlists   Music, Videos
+        seasons     Videos
+        sets        Videos
+        songs       Music
+        studios     Music, Videos
+        tags        Music, Videos
+        tvshows     Videos
+        videos      Videos
+        years       Music, Videos
+        =========== =========================================
 
         @python_v18 Added new function.
 
@@ -4770,7 +4771,7 @@ class WindowXML(Window):
             ..
         """
         pass
-    
+
     def getCurrentContainerId(self) -> int:
         """
         Get the id of the currently visible container.
@@ -4784,7 +4785,7 @@ class WindowXML(Window):
             ..
         """
         return 0
-    
+
 
 class WindowXMLDialog(WindowXML):
     """
@@ -4827,7 +4828,7 @@ class WindowXMLDialog(WindowXML):
         ...
         </control>
     """
-    
+
     def __init__(self, xmlFilename: str,
                  scriptPath: str,
                  defaultSkin: str = "Default",

--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -9,6 +9,8 @@ through Kodi's standard menu structure. While plugins don't have the same
 flexibility as scripts, they boast significantly quicker development time and a
 more consistent user experience.
 """
+import xbmcgui
+
 from typing import List, Tuple, Optional
 
 __kodistubs__ = True
@@ -171,76 +173,76 @@ def addSortMethod(handle: int,
     :param sortMethod: integer - see available sort methods at the bottom (or see SortUtils).
 
     =================================================================== ================================================
-    Value                                                               Description                                             
+    Value                                                               Description
     =================================================================== ================================================
-    xbmcplugin.SORT_METHOD_NONE                                         Do not sort                                             
-    xbmcplugin.SORT_METHOD_LABEL                                        Sort by label                                           
-    xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE                             Sort by the label and ignore "The" before               
-    xbmcplugin.SORT_METHOD_DATE                                         Sort by the date                                        
-    xbmcplugin.SORT_METHOD_SIZE                                         Sort by the size                                        
-    xbmcplugin.SORT_METHOD_FILE                                         Sort by the file                                        
-    xbmcplugin.SORT_METHOD_DRIVE_TYPE                                   Sort by the drive type                                  
-    xbmcplugin.SORT_METHOD_TRACKNUM                                     Sort by the track number                                
-    xbmcplugin.SORT_METHOD_DURATION                                     Sort by the duration                                    
-    xbmcplugin.SORT_METHOD_TITLE                                        Sort by the title                                       
-    xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE                             Sort by the title and ignore "The" before               
-    xbmcplugin.SORT_METHOD_ARTIST                                       Sort by the artist                                      
-    xbmcplugin.SORT_METHOD_ARTIST_IGNORE_THE                            Sort by the artist and ignore "The" before              
-    xbmcplugin.SORT_METHOD_ALBUM                                        Sort by the album                                       
-    xbmcplugin.SORT_METHOD_ALBUM_IGNORE_THE                             Sort by the album and ignore "The" before               
-    xbmcplugin.SORT_METHOD_GENRE                                        Sort by the genre                                       
-    xbmcplugin.SORT_SORT_METHOD_VIDEO_YEAR, xbmcplugin.SORT_METHOD_YEAR Sort by the year                                        
-    xbmcplugin.SORT_METHOD_VIDEO_RATING                                 Sort by the video rating                                
-    xbmcplugin.SORT_METHOD_PROGRAM_COUNT                                Sort by the program count                               
-    xbmcplugin.SORT_METHOD_PLAYLIST_ORDER                               Sort by the playlist order                              
-    xbmcplugin.SORT_METHOD_EPISODE                                      Sort by the episode                                     
-    xbmcplugin.SORT_METHOD_VIDEO_TITLE                                  Sort by the video title                                 
-    xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE                             Sort by the video sort title                            
+    xbmcplugin.SORT_METHOD_NONE                                         Do not sort
+    xbmcplugin.SORT_METHOD_LABEL                                        Sort by label
+    xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE                             Sort by the label and ignore "The" before
+    xbmcplugin.SORT_METHOD_DATE                                         Sort by the date
+    xbmcplugin.SORT_METHOD_SIZE                                         Sort by the size
+    xbmcplugin.SORT_METHOD_FILE                                         Sort by the file
+    xbmcplugin.SORT_METHOD_DRIVE_TYPE                                   Sort by the drive type
+    xbmcplugin.SORT_METHOD_TRACKNUM                                     Sort by the track number
+    xbmcplugin.SORT_METHOD_DURATION                                     Sort by the duration
+    xbmcplugin.SORT_METHOD_TITLE                                        Sort by the title
+    xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE                             Sort by the title and ignore "The" before
+    xbmcplugin.SORT_METHOD_ARTIST                                       Sort by the artist
+    xbmcplugin.SORT_METHOD_ARTIST_IGNORE_THE                            Sort by the artist and ignore "The" before
+    xbmcplugin.SORT_METHOD_ALBUM                                        Sort by the album
+    xbmcplugin.SORT_METHOD_ALBUM_IGNORE_THE                             Sort by the album and ignore "The" before
+    xbmcplugin.SORT_METHOD_GENRE                                        Sort by the genre
+    xbmcplugin.SORT_SORT_METHOD_VIDEO_YEAR, xbmcplugin.SORT_METHOD_YEAR Sort by the year
+    xbmcplugin.SORT_METHOD_VIDEO_RATING                                 Sort by the video rating
+    xbmcplugin.SORT_METHOD_PROGRAM_COUNT                                Sort by the program count
+    xbmcplugin.SORT_METHOD_PLAYLIST_ORDER                               Sort by the playlist order
+    xbmcplugin.SORT_METHOD_EPISODE                                      Sort by the episode
+    xbmcplugin.SORT_METHOD_VIDEO_TITLE                                  Sort by the video title
+    xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE                             Sort by the video sort title
     xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE                  Sort by the video sort title and ignore
                                                                         "The" before
-    xbmcplugin.SORT_METHOD_PRODUCTIONCODE                               Sort by the production code                             
-    xbmcplugin.SORT_METHOD_SONG_RATING                                  Sort by the song rating                                 
-    xbmcplugin.SORT_METHOD_MPAA_RATING                                  Sort by the mpaa rating                                 
-    xbmcplugin.SORT_METHOD_VIDEO_RUNTIME                                Sort by video runtime                                   
-    xbmcplugin.SORT_METHOD_STUDIO                                       Sort by the studio                                      
-    xbmcplugin.SORT_METHOD_STUDIO_IGNORE_THE                            Sort by the studio and ignore "The" before              
-    xbmcplugin.SORT_METHOD_UNSORTED                                     Use list not sorted                                     
-    xbmcplugin.SORT_METHOD_BITRATE                                      Sort by the bitrate                                     
-    xbmcplugin.SORT_METHOD_LISTENERS                                    Sort by the listeners                                   
-    xbmcplugin.SORT_METHOD_COUNTRY                                      Sort by the country                                     
-    xbmcplugin.SORT_METHOD_DATEADDED                                    Sort by the added date                                  
-    xbmcplugin.SORT_METHOD_FULLPATH                                     Sort by the full path name                              
+    xbmcplugin.SORT_METHOD_PRODUCTIONCODE                               Sort by the production code
+    xbmcplugin.SORT_METHOD_SONG_RATING                                  Sort by the song rating
+    xbmcplugin.SORT_METHOD_MPAA_RATING                                  Sort by the mpaa rating
+    xbmcplugin.SORT_METHOD_VIDEO_RUNTIME                                Sort by video runtime
+    xbmcplugin.SORT_METHOD_STUDIO                                       Sort by the studio
+    xbmcplugin.SORT_METHOD_STUDIO_IGNORE_THE                            Sort by the studio and ignore "The" before
+    xbmcplugin.SORT_METHOD_UNSORTED                                     Use list not sorted
+    xbmcplugin.SORT_METHOD_BITRATE                                      Sort by the bitrate
+    xbmcplugin.SORT_METHOD_LISTENERS                                    Sort by the listeners
+    xbmcplugin.SORT_METHOD_COUNTRY                                      Sort by the country
+    xbmcplugin.SORT_METHOD_DATEADDED                                    Sort by the added date
+    xbmcplugin.SORT_METHOD_FULLPATH                                     Sort by the full path name
     xbmcplugin.SORT_METHOD_LABEL_IGNORE_FOLDERS                         Sort by the label names and ignore related
                                                                         folder names
-    xbmcplugin.SORT_METHOD_LASTPLAYED                                   Sort by last played date                                
-    xbmcplugin.SORT_METHOD_PLAYCOUNT                                    Sort by the play count                                  
-    xbmcplugin.SORT_METHOD_CHANNEL                                      Sort by the channel                                     
-    xbmcplugin.SORT_METHOD_DATE_TAKEN                                   Sort by the taken date                                  
-    xbmcplugin.SORT_METHOD_VIDEO_USER_RATING                            Sort by the rating of the user of video                 
-    xbmcplugin.SORT_METHOD_SONG_USER_RATING                             Sort by the rating of the user of song                  
+    xbmcplugin.SORT_METHOD_LASTPLAYED                                   Sort by last played date
+    xbmcplugin.SORT_METHOD_PLAYCOUNT                                    Sort by the play count
+    xbmcplugin.SORT_METHOD_CHANNEL                                      Sort by the channel
+    xbmcplugin.SORT_METHOD_DATE_TAKEN                                   Sort by the taken date
+    xbmcplugin.SORT_METHOD_VIDEO_USER_RATING                            Sort by the rating of the user of video
+    xbmcplugin.SORT_METHOD_SONG_USER_RATING                             Sort by the rating of the user of song
     =================================================================== ================================================
 
     :param labelMask: [opt] string - the label mask to use for the first label.  applies to:
 
-    ========================== ======================= 
-    sortMethod                 labelMask               
-    ========================== ======================= 
-    SORT_METHOD_TRACKNUM       Defaults to``[%N. ]%T`` 
-    SORT_METHOD_EPISODE        Defaults to``%H. %T``   
-    SORT_METHOD_PRODUCTIONCODE Defaults to``%H. %T``   
-    All other sort methods     Defaults to``%T``       
-    ========================== ======================= 
+    ========================== =======================
+    sortMethod                 labelMask
+    ========================== =======================
+    SORT_METHOD_TRACKNUM       Defaults to``[%N. ]%T``
+    SORT_METHOD_EPISODE        Defaults to``%H. %T``
+    SORT_METHOD_PRODUCTIONCODE Defaults to``%H. %T``
+    All other sort methods     Defaults to``%T``
+    ========================== =======================
 
     :param label2Mask: [opt] string - the label mask to use for the second label. Defaults
         to``%D``  applies to:
 
     ================================ ==================== =======================================
-    SORT_METHOD_NONE                 SORT_METHOD_UNSORTED SORT_METHOD_VIDEO_TITLE                 
-    SORT_METHOD_TRACKNUM             SORT_METHOD_FILE     SORT_METHOD_TITLE                       
-    SORT_METHOD_TITLE_IGNORE_THE     SORT_METHOD_LABEL    SORT_METHOD_LABEL_IGNORE_THE            
-    SORT_METHOD_VIDEO_SORT_TITLE     SORT_METHOD_FULLPATH SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE 
-    SORT_METHOD_LABEL_IGNORE_FOLDERS SORT_METHOD_CHANNEL                                          
-    ================================ ==================== ======================================= 
+    SORT_METHOD_NONE                 SORT_METHOD_UNSORTED SORT_METHOD_VIDEO_TITLE
+    SORT_METHOD_TRACKNUM             SORT_METHOD_FILE     SORT_METHOD_TITLE
+    SORT_METHOD_TITLE_IGNORE_THE     SORT_METHOD_LABEL    SORT_METHOD_LABEL_IGNORE_THE
+    SORT_METHOD_VIDEO_SORT_TITLE     SORT_METHOD_FULLPATH SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE
+    SORT_METHOD_LABEL_IGNORE_FOLDERS SORT_METHOD_CHANNEL
+    ================================ ==================== =======================================
 
     .. note::
         to add multiple sort methods just call the method multiple times.
@@ -310,10 +312,10 @@ def setContent(handle: int, content: str) -> None:
     Available content strings
 
     ====== ======= ======== ===========
-    files  songs   artists  albums      
-    movies tvshows episodes musicvideos 
-    videos images  games                
-    ====== ======= ======== =========== 
+    files  songs   artists  albums
+    movies tvshows episodes musicvideos
+    videos images  games
+    ====== ======= ======== ===========
 
     Use **videos** for all videos which do not apply to the more specific mentioned
     ones like "movies", "episodes" etc. A good example is youtube.

--- a/xbmcvfs.py
+++ b/xbmcvfs.py
@@ -20,11 +20,11 @@ class File:
     :param mode: [opt] string Additional mode options (if no mode is supplied, the
         default is Open for Read).
 
-    ==== ============== 
-    Mode Description    
-    ==== ============== 
-    w    Open for write 
-    ==== ============== 
+    ==== ==============
+    Mode Description
+    ==== ==============
+    w    Open for write
+    ==== ==============
 
     @python_v19 Added context manager support
 
@@ -41,7 +41,7 @@ class File:
             ..
             ..
     """
-    
+
     def __init__(self, filepath: str, mode: Optional[str] = None) -> None:
         pass
 
@@ -50,7 +50,7 @@ class File:
 
     def __exit__(self, exc_type, exc_val, exc_tb):  # Required for context manager
         pass
-    
+
     def read(self, numBytes: int = 0) -> str:
         """
         Read file parts as string.
@@ -74,7 +74,7 @@ class File:
                 ..
         """
         return ""
-    
+
     def readBytes(self, numBytes: int = 0) -> bytearray:
         """
         Read bytes from file.
@@ -98,7 +98,7 @@ class File:
                 ..
         """
         return bytearray()
-    
+
     def write(self, buffer: Union[str,  bytes,  bytearray]) -> bool:
         """
         To write given data in file.
@@ -122,7 +122,7 @@ class File:
                 ..
         """
         return True
-    
+
     def size(self) -> int:
         """
         Get the file size.
@@ -145,7 +145,7 @@ class File:
                 ..
         """
         return 0
-    
+
     def seek(self, seekBytes: int, iWhence: int = 0) -> int:
         """
         Seek to position in file.
@@ -172,7 +172,7 @@ class File:
                 ..
         """
         return 0
-    
+
     def tell(self) -> int:
         """
         Get the current position in the file.
@@ -197,7 +197,7 @@ class File:
                 ..
         """
         return 0
-    
+
     def close(self) -> None:
         """
         Close opened file.
@@ -217,7 +217,7 @@ class File:
                 ..
         """
         pass
-    
+
 
 class Stat:
     """
@@ -237,10 +237,10 @@ class Stat:
         modified = st.st_mtime()
         ..
     """
-    
+
     def __init__(self, path: str) -> None:
         pass
-    
+
     def st_mode(self) -> int:
         """
         To get file protection.
@@ -248,7 +248,7 @@ class Stat:
         :return: st_mode
         """
         return 0
-    
+
     def st_ino(self) -> int:
         """
         To get inode number.
@@ -256,7 +256,7 @@ class Stat:
         :return: st_ino
         """
         return 0
-    
+
     def st_dev(self) -> int:
         """
         To get ID of device containing file.
@@ -266,7 +266,7 @@ class Stat:
         :return: st_dev
         """
         return 0
-    
+
     def st_nlink(self) -> int:
         """
         To get number of hard links.
@@ -274,7 +274,7 @@ class Stat:
         :return: st_nlink
         """
         return 0
-    
+
     def st_uid(self) -> int:
         """
         To get user ID of owner.
@@ -282,7 +282,7 @@ class Stat:
         :return: st_uid
         """
         return 0
-    
+
     def st_gid(self) -> int:
         """
         To get group ID of owner.
@@ -290,7 +290,7 @@ class Stat:
         :return: st_gid
         """
         return 0
-    
+
     def st_size(self) -> int:
         """
         To get total size, in bytes.
@@ -302,7 +302,7 @@ class Stat:
         :return: st_size
         """
         return 0
-    
+
     def st_atime(self) -> int:
         """
         To get time of last access.
@@ -310,7 +310,7 @@ class Stat:
         :return: st_atime
         """
         return 0
-    
+
     def st_mtime(self) -> int:
         """
         To get time of last modification.
@@ -318,7 +318,7 @@ class Stat:
         :return: st_mtime
         """
         return 0
-    
+
     def st_ctime(self) -> int:
         """
         To get time of last status change.
@@ -326,7 +326,7 @@ class Stat:
         :return: st_ctime
         """
         return 0
-    
+
 
 def copy(strSource: str, strDestination: str) -> bool:
     """


### PR DESCRIPTION
While working on Kodi add-ons from Visual Studio Code (VSC), some code completion isn't coming through because it can't resolve imports.

For example, in `xbmc.py`, there is `xbmcgui.ListItem`, but `xbmcgui` is not imported so VSC treats the type as `Any`.

Note that `xbmc.py` and `xbmcgui.py` have a circular dependency, but I don't think this is an immediate issue since the project isn't actually getting executed. VSC is still able to resolve types. :+1: 

This just adds import at the top of the relevant files so that they can be resolved.

## Screenshots

![](https://github.com/romanvm/Kodistubs/assets/22801583/4b5b0ba5-8a8f-4416-8395-88a8da2248e5)
> This previously had the type `Any`, but now VSC is able to show code completion and type hints propertly.

## Chore

My editor automatically trimmed trailing spaces from the files too. Would it be fine to keep that in?

When reviewing, I'd recommend clicking the cog and enabling **Hide whitespace**.

![](https://github.com/romanvm/Kodistubs/assets/22801583/8020bb43-2a67-4414-9a13-bc97a271b34e)